### PR TITLE
Clean up grammar in doc example descriptions

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -76,7 +76,7 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudAutocomplete accepts keys to keyboard navigation.</MudText>
+                    <MudText>MudAutocomplete supports keyboard navigation keys.</MudText>
                     <br />
                     <MudText><CodeInline>Escape</CodeInline> or <CodeInline>Alt+ArrowUp</CodeInline> keys to close dropdown</MudText>
                     <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> or <CodeInline>ArrowDown</CodeInline> or <CodeInline>ArrowUp</CodeInline> keys to open dropdown</MudText>
@@ -84,7 +84,7 @@
                     <MudText><CodeInline>ArrowDown</CodeInline> key to select/navigate next item</MudText>
                     <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> keys to select item</MudText>
                     <br />
-                    <MudText>*If search func didn't return any value, keys can't open the dropdown.</MudText>
+                    <MudText>*If the search function doesn't return any values, keyboard shortcuts can't open the dropdown.</MudText>
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(AutocompleteUsageExample)">
@@ -95,7 +95,7 @@
         <DocsPageSection>
             <SectionHeader Title="Progress">
                 <Description>
-                    <MudText>When fetching data from a remote datasource MudAutocomplete can visually indicate that it is awaiting results. Following settings are available:</MudText>
+                    <MudText>When fetching data from a remote data source MudAutocomplete can visually indicate that it is awaiting results. The following settings are available:</MudText>
                     <br />
                     <MudText><CodeInline>ShowProgressIndicator</CodeInline>: show circular progress indicator.</MudText>
                     <MudText><CodeInline>ProgressIndicatorTemplate</CodeInline>: replace the default circular progress indicator with a custom one.</MudText>
@@ -128,7 +128,7 @@
         <DocsPageSection>
             <SectionHeader Title="Cancellation Token">
                 <Description>
-                    <MudText>Autocomplete can cancel request if the user types new input</MudText>
+                    <MudText>Autocomplete can cancel the request if the user types new input</MudText>
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(AutocompleteCancellationTokenExample)">

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -63,8 +63,8 @@
         <DocsPageSection>
             <SectionHeader Title="Validation">
                 <Description>
-                    Below there are different examples of validation with the MudAutocomplete control. The validation uses an EditForm or a MudForm. The result and display will vary if the
-                    <CodeInline Tag="true">CoerceValue</CodeInline> option is set to <CodeInline Tag="true">true</CodeInline>. But also if characters are typed into the control instead of a selection from the dropdown list.<br />
+                    Below are different validation examples for the MudAutocomplete control. They use an EditForm or a MudForm, and the result and display vary if the
+                    <CodeInline Tag="true">CoerceValue</CodeInline> option is set to <CodeInline Tag="true">true</CodeInline> or if characters are typed into the control instead of choosing from the dropdown list.<br />
                     For more info on form validation, check out <MudLink Href="/components/form">Form</MudLink>.
                 </Description>
             </SectionHeader>
@@ -76,7 +76,7 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudAutocomplete supports keyboard navigation keys.</MudText>
+                    <MudText>MudAutocomplete supports keyboard navigation.</MudText>
                     <br />
                     <MudText><CodeInline>Escape</CodeInline> or <CodeInline>Alt+ArrowUp</CodeInline> keys to close dropdown</MudText>
                     <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> or <CodeInline>ArrowDown</CodeInline> or <CodeInline>ArrowUp</CodeInline> keys to open dropdown</MudText>

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
@@ -74,7 +74,8 @@
                     <br />
                     Indeterminate, True, False, True, False...
                     <br />
-                    It is not possible to obtain the Indeterminate state again. Except by resetting the value to <CodeInline>Null</CodeInline>. Or, by setting <CodeInline>TriState="true"</CodeInline>, you can get the Indeterminate state after the False state.
+                    It is not possible to obtain the Indeterminate state again unless you reset the value to <CodeInline>Null</CodeInline>.
+                    Alternatively, by setting <CodeInline>TriState="true"</CodeInline>, you can get the Indeterminate state after the False state.
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(CheckboxIndeterminateExample)">
@@ -112,11 +113,11 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudCheckBox accepts keys to keyboard navigation.</MudText>
+                    <MudText>MudCheckBox supports keyboard navigation keys.</MudText>
                     <br />
                     <MudText><CodeInline>Space</CodeInline> key to toggle state true/false/(if TriState is true) indeterminate</MudText>
-                    <MudText><CodeInline>Delete</CodeInline> key to set UnChecked</MudText>
-                    <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> keys to set Checked</MudText>
+                    <MudText><CodeInline>Delete</CodeInline> key to set unchecked</MudText>
+                    <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> keys to set checked</MudText>
                     <MudText><CodeInline>Backspace</CodeInline> key to set indeterminate (only TriState is true)</MudText>
                     <MudText>*Disabled or ReadOnly checkboxes cannot be changed by keys.</MudText>
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
@@ -103,7 +103,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="ReadOnly Mode">
-                <Description>Setting <CodeInline>ReadOnly="true"</CodeInline> will make the checkbox control stop listening to user input.</Description>
+                <Description>Setting <CodeInline>ReadOnly="true"</CodeInline> stops the checkbox control from listening to user input.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(CheckboxReadOnlyExample)" ShowCode="false" Block="true">
                 <CheckboxReadOnlyExample />
@@ -113,12 +113,12 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudCheckBox supports keyboard navigation keys.</MudText>
+                    <MudText>MudCheckBox supports keyboard navigation.</MudText>
                     <br />
-                    <MudText><CodeInline>Space</CodeInline> key to toggle state true/false/(if TriState is true) indeterminate</MudText>
+                    <MudText><CodeInline>Space</CodeInline> key to toggle between true/false/(when TriState is true) indeterminate</MudText>
                     <MudText><CodeInline>Delete</CodeInline> key to set unchecked</MudText>
                     <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> keys to set checked</MudText>
-                    <MudText><CodeInline>Backspace</CodeInline> key to set indeterminate (only TriState is true)</MudText>
+                    <MudText><CodeInline>Backspace</CodeInline> key to set indeterminate (only when TriState is true)</MudText>
                     <MudText>*Disabled or ReadOnly checkboxes cannot be changed by keys.</MudText>
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/ChipSet/ChipSetPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChipSet/ChipSetPage.razor
@@ -11,7 +11,7 @@
                 <Description>
                     Chipset will maintain a selection of chips for you. By default, the <CodeInline>SelectionMode</CodeInline> is <CodeInline>SelectionMode.SingleSelection</CodeInline>.
                     In this mode you can choose a single value. Similar to a radio button you can switch the value by clicking on a different chip but it is not possible to unselect the selected choice by
-                    clicking a second time. <CodeInline>SelectionMode="SelectionMode.ToggleSelection"</CodeInline> is a single selection which also allows to unselect the selected chip.
+                    clicking a second time. <CodeInline>SelectionMode="SelectionMode.ToggleSelection"</CodeInline> is a single selection which also allows you to unselect the selected chip.
                     To get or set the selected value use <CodeInline>@@bind-SelectedValue</CodeInline>.
 
                     <MudAlert Severity="Severity.Info" Class="my-3">
@@ -52,7 +52,7 @@
         <DocsPageSection>
             <SectionHeader Title="Default chips">
                 <Description>
-                    Chips which have<CodeInline>Default="true"</CodeInline> will be initially selected.
+                    Chips that have <CodeInline>Default="true"</CodeInline> will be initially selected.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(ChipSetDefaultChipsExample)" Block="true">
@@ -74,7 +74,7 @@
         <DocsPageSection>
             <SectionHeader Title="Variants">
                 <Description>
-                    The chip's look different when selected depending on its initial <CodeInline>Variant</CodeInline>.
+                    Chips look different when selected depending on their initial <CodeInline>Variant</CodeInline>.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(ChipSetVariantsExample)" Block="true">
@@ -85,7 +85,7 @@
         <DocsPageSection>
             <SectionHeader Title="Selected Color">
                 <Description>
-                    The chip's selected color can be changed with the <CodeInline>SelectedColor</CodeInline> property, by default it has the same color as the chip.
+                    You can change the chip's selected color with the <CodeInline>SelectedColor</CodeInline> property; by default it has the same color as the chip.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(ChipSetSelectedColorExample)" Block="true">

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
@@ -153,7 +153,7 @@
         <DocsPageSection>
             <SectionHeader Title="Fixed Values Usage">
                 <Description>
-                    You can set fix values for day, month or year via <CodeInline>FixDay</CodeInline>, <CodeInline>FixMonth</CodeInline> and <CodeInline>FixYear</CodeInline>, default value is null for all of them.
+                    You can set fixed values for day, month or year via <CodeInline>FixDay</CodeInline>, <CodeInline>FixMonth</CodeInline> and <CodeInline>FixYear</CodeInline>, default value is null for all of them.
                     This in combination with the <CodeInline>OpenTo</CodeInline> parameter allows for Year-Month Pickers, where the user only selects those two values or Month-Day Pickers where the year is already given.
                     This changes the behaviour of the picker so only views that can be set are displayed.
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Components/Image/ImagePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Image/ImagePage.razor
@@ -8,7 +8,7 @@
             <SectionHeader Title="Usage">
                 <Description>
                     <CodeInline>MudImage</CodeInline> is used to embed an image in an HTML page. Images are not technically inserted into a page, but are linked to a file.<br/>
-                    The component represent the <CodeInline>&#60;img&#62;</CodeInline> tag  and creates a holding space for the referenced image.
+                    The component represents the <CodeInline>&#60;img&#62;</CodeInline> tag and creates a holding space for the referenced image.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(ImageUsageExample)">
@@ -29,7 +29,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Size">
-                <Description>Size can be directly set on the image with the <CodeInline>Width</CodeInline> and <CodeInline>Height</CodeInline> property, it can also be useful to set this even if you want a responsive image, setting them will make the image take up set space even before they are loaded which can be useful if your pictures takes long time to load.</Description>
+                <Description>Size can be set directly on the image with the <CodeInline>Width</CodeInline> and <CodeInline>Height</CodeInline> properties. This can be useful even for responsive images because setting them reserves space before the images load, which helps when pictures take a long time to appear.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(ImageSizeExample)">
                 <ImageSizeExample />
@@ -40,7 +40,7 @@
             <SectionHeader Title="Responsive Images">
                 <Description>
                     To get responsive images set the <CodeInline>Fluid</CodeInline> property to true. This applies <CodeInline SecondaryColor="true">max-width: 100%; and height: auto;</CodeInline> so the image scales with the parent's width.<br/>
-                    Resize the example bellow to see how the image scales with the parents with.
+                    Resize the example below to see how the image scales with the parent's width.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(ImageResponsiveExample)" Block="true" FullWidth="true">
@@ -53,7 +53,7 @@
         <DocsPageSection>
             <SectionHeader Title="Image Fit">
                 <Description>
-                    Use <CodeInline>ObjectFit</CodeInline> to controll how a image should be resized.
+                    Use <CodeInline>ObjectFit</CodeInline> to control how an image should be resized.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(ImageFitExample)" Block="true" ShowCode="false">
@@ -64,7 +64,7 @@
         <DocsPageSection>
             <SectionHeader Title="Image Position">
                 <Description>
-                    With the <CodeInline>ObjectPosition</CodeInline> property you can specify how a image should be positioned within its container.
+                    With the <CodeInline>ObjectPosition</CodeInline> property you can specify how an image should be positioned within its container.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(ImagePositionExample)" Block="true" ShowCode="false">

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -146,7 +146,7 @@
         <DocsPageSection>
             <SectionHeader Title="Placement">
                 <Description>
-                    The component uses <MudLink Href="/components/popover">MudPopover</MudLink> to place it's list of items. It can be controlled with <CodeInline>AnchorOrigin</CodeInline> and <CodeInline>TransformOrigin</CodeInline>
+                    The component uses <MudLink Href="/components/popover">MudPopover</MudLink> to place its list of items. It can be controlled with <CodeInline>AnchorOrigin</CodeInline> and <CodeInline>TransformOrigin</CodeInline>.
                     To change where the popover should start from you only need to change the <CodeInline>AnchorOrigin</CodeInline>. <MudLink Color="Color.Secondary" Href="/components/popover">Read more on popover's page.</MudLink>
                 </Description>
             </SectionHeader>
@@ -158,7 +158,7 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudSelect accepts keys to keyboard navigation.</MudText>
+                    <MudText>MudSelect supports keyboard navigation keys.</MudText>
                     <br />
                     <MudText><CodeInline>Space</CodeInline> key to toggle dropdown open/close</MudText>
                     <MudText><CodeInline>Escape</CodeInline> or <CodeInline>Alt+ArrowUp</CodeInline> keys to close dropdown</MudText>

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -158,7 +158,7 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudSelect supports keyboard navigation keys.</MudText>
+                    <MudText>MudSelect supports keyboard navigation.</MudText>
                     <br />
                     <MudText><CodeInline>Space</CodeInline> key to toggle dropdown open/close</MudText>
                     <MudText><CodeInline>Escape</CodeInline> or <CodeInline>Alt+ArrowUp</CodeInline> keys to close dropdown</MudText>
@@ -169,7 +169,7 @@
                     <MudText><CodeInline>End</CodeInline> key to select/navigate last item</MudText>
                     <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> keys to select item (MultiSelect only)</MudText>
                     <MudText><CodeInline>Ctrl+A</CodeInline> key to toggle select all/clear all items (MultiSelect only)</MudText>
-                    <MudText><CodeInline>Printable Characters</CodeInline> to set the first item in the list whose text starts with that character. Press again to select the next item with the same status.</MudText>
+                    <MudText><CodeInline>Printable Characters</CodeInline> to highlight the first item in the list whose text starts with that character. Press again to move to the next item with the same starting character.</MudText>
                     <br />
                     <MudText>*Disabled items cannot be selected by keys.</MudText>
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
@@ -41,7 +41,7 @@
         <DocsPageSection>
             <SectionHeader Title="Thumb Icon">
                 <Description>
-                    An icon can be determined with <CodeInline>ThumbIcon</CodeInline> parameter.
+                    An icon can be specified with the <CodeInline>ThumbIcon</CodeInline> parameter.
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(SwitchWithIconExample)" ShowCode="false">
@@ -79,7 +79,7 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudSwitch accepts keys to keyboard navigation.</MudText>
+                    <MudText>MudSwitch supports keyboard navigation keys.</MudText>
                     <br />
                     <MudText><CodeInline>Space</CodeInline> key to toggle state true/false</MudText>
                     <MudText><CodeInline>Delete</CodeInline> or <CodeInline>ArrowLeft</CodeInline> keys to set UnChecked</MudText>

--- a/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
@@ -69,7 +69,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="ReadOnly mode">
-                <Description>Setting <CodeInline>ReadOnly="true"</CodeInline> will make the switch control stop listening to user inputs.</Description>
+                <Description>Setting <CodeInline>ReadOnly="true"</CodeInline> stops the switch control from listening to user input.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(SwitchReadOnlyExample)" Block="true">
                 <SwitchReadOnlyExample />
@@ -79,7 +79,7 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudSwitch supports keyboard navigation keys.</MudText>
+                    <MudText>MudSwitch supports keyboard navigation.</MudText>
                     <br />
                     <MudText><CodeInline>Space</CodeInline> key to toggle state true/false</MudText>
                     <MudText><CodeInline>Delete</CodeInline> or <CodeInline>ArrowLeft</CodeInline> keys to set UnChecked</MudText>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -21,7 +21,7 @@
             <SectionHeader Title="Click Event and display for selected Row">
                 <Description>
                     The <CodeInline>RowClassFunc</CodeInline> function can be used to customize the display of the selected row. <CodeInline>RowClickEvent</CodeInline> is triggered each time the row is clicked. 
-                    In addition to that the <CodeInline>RowClass</CodeInline> can be used to apply a general row style independent of the selection state. In this example we show a pointer curser.
+                    In addition, the <CodeInline>RowClass</CodeInline> can be used to apply a general row style independent of the selection state. In this example we show a pointer cursor.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(TableRowClassFuncExample)" ShowCode="false" Block="true" FullWidth="true">
@@ -64,7 +64,7 @@
                     The properties <CodeInline>RowsPerPageString</CodeInline>, <CodeInline>InfoFormat</CodeInline> and <CodeInline>AllItemsText</CodeInline> can be used to customize the displayed text.
                     The properties <CodeInline>HideRowsPerPage</CodeInline>, <CodeInline>HidePageNumber</CodeInline> and <CodeInline>HidePagination</CodeInline> can be used to hide the corresponding information.
                     <br /><br />
-                    See <MudLink Href="@ApiLink.GetApiLinkFor(typeof(MudTablePager))">TablePager API</MudLink> for more informations.
+                    See <MudLink Href="@ApiLink.GetApiLinkFor(typeof(MudTablePager))">TablePager API</MudLink> for more information.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
                         <CodeInline>@("RowsPerPage")</CodeInline> parameter of MudTable is independent of <CodeInline>@("PageSizeOptions")</CodeInline> parameter of PagerContent. Therefore, the RowsPerPage value does not have
                         to be one of the values in the PageSizeOptions list. If the table pager is shown you should make sure the value of RowsPerPage is also available in the PageSizeOptions list, otherwise the users can not go back to this RowsPerPage value once they have chosen another one.
@@ -160,7 +160,7 @@
         <DocsPageSection>
             <SectionHeader Title="Server Side Filtering, Sorting and Pagination">
                 <Description>
-                    Set <CodeInline>ServerData</CodeInline> to load data from the backend that is filtered, sorted and paginated. Table will call this async function whenever the user navigates
+                    Set <CodeInline>ServerData</CodeInline> to load data from the backend that is filtered, sorted and paginated. The table will call this async function whenever the user navigates
                     the pager or changes sorting by clicking on the sort header icons. In this example, we also show how to force the table to update when the search textfield blurs, so that the table reloads server-filtered data.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
                         Note: with a <CodeInline>ServerData</CodeInline> func you don't need <CodeInline>Items</CodeInline> and <CodeInline>Filter</CodeInline>.
@@ -175,8 +175,8 @@
         <DocsPageSection>
             <SectionHeader Title="Server Side Data With Cancellation">
                 <Description>
-                    Use the <CodeInline>CancellationToken</CodeInline> to detect when a request for data has been superceded by a new request.  By forwarding the token to methods which support it,
-                    such as common <CodeInline>HttpClient</CodeInline> or <CodeInline>DbContent</CodeInline> methods, the table can perform well even with frequent updates.
+                    Use the <CodeInline>CancellationToken</CodeInline> to detect when a request for data has been superseded by a new request. By forwarding the token to methods which support it,
+                    such as common <CodeInline>HttpClient</CodeInline> or <CodeInline>DbContext</CodeInline> methods, the table can perform well even with frequent updates.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
                         Note: When using <CodeInline>ServerData</CodeInline>, you don't need <CodeInline>Items</CodeInline> or <CodeInline>Filter</CodeInline>.
                     </MudAlert>
@@ -233,7 +233,7 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Table With related data">
+            <SectionHeader Title="Table with related data">
                 <Description>
                     Making use of the <CodeInline>&lt;ChildRowContent&gt;</CodeInline> allows more control over the layout for scenarios such as showing the related address data for each person below.
                 </Description>
@@ -294,7 +294,7 @@
         <DocsPageSection>
             <SectionHeader Title="Grouping (Basic) - Initially collapsed">
                 <Description>
-                    Displays items in a grouped way, but the groups are all collapsed as default. <br />
+                    Displays items in a grouped way, but the groups are all collapsed by default. <br />
                     Groups can be expanded or collapsed all at once by calling <CodeInline>ExpandAllGroups()</CodeInline> or <CodeInline>CollapseAllGroups()</CodeInline>.
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
@@ -113,7 +113,7 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudTimePicker accepts keys to keyboard navigation.</MudText>
+                    <MudText>MudTimePicker supports keyboard navigation keys.</MudText>
                     <br />
                     <MudText><CodeInline>Escape</CodeInline> or <CodeInline>Alt+ArrowUp</CodeInline> keys to close dropdown</MudText>
                     <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> or <CodeInline>ArrowDown</CodeInline> or <CodeInline>ArrowUp</CodeInline> keys to open dropdown</MudText>

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
@@ -113,11 +113,11 @@
         <DocsPageSection>
             <SectionHeader Title="Keyboard Navigation">
                 <Description>
-                    <MudText>MudTimePicker supports keyboard navigation keys.</MudText>
+                    <MudText>MudTimePicker supports keyboard navigation.</MudText>
                     <br />
                     <MudText><CodeInline>Escape</CodeInline> or <CodeInline>Alt+ArrowUp</CodeInline> keys to close dropdown</MudText>
                     <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> or <CodeInline>ArrowDown</CodeInline> or <CodeInline>ArrowUp</CodeInline> keys to open dropdown</MudText>
-                    <MudText><CodeInline>Space</CodeInline> key to toggle open/close the picker (if it is not editable)</MudText>
+                    <MudText><CodeInline>Space</CodeInline> key to toggle open/close the picker (when it is not editable)</MudText>
                     <MudText><CodeInline>ArrowUp</CodeInline> or <CodeInline>Ctrl+ArrowRight</CodeInline> keys to increase hour by 1</MudText>
                     <MudText><CodeInline>ArrowDown</CodeInline> or <CodeInline>Ctrl+ArrowLeft</CodeInline> keys to decrease hour by 1</MudText>
                     <MudText><CodeInline>ArrowRight</CodeInline> and <CodeInline>ArrowLeft</CodeInline> keys to increase/decrease minute by 1</MudText>


### PR DESCRIPTION
## Summary
- clarify the repeated keyboard navigation sentences across several component docs
- fix grammar issues in autocomplete progress and cancellation descriptions
- refine the checkbox indeterminate state explanation for clarity

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b259ac80832889ab335e5a551069)