### PR TITLE
Fix grammar in theming and colors documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ For more details, see the [complete installation guide](https://mudblazor.com/ge
 
 ## 🤝 Contributing
 
-Contributions from the community are what makes MudBlazor successful.  
+Contributions from the community are what make MudBlazor successful.  
 
 💬 Feel free to chat with us [on Discord](https://discord.gg/mudblazor) to get feedback before diving in.  
 📚 Check out our [contribution guidelines](/CONTRIBUTING.md) to get started and learn more about how the project works.  

--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Overview.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Overview.razor
@@ -7,8 +7,8 @@
         <DocsPageSection>
             <SectionHeader Title="Theme Provider">
                 <Description>
-                    The Theme provider specifies all the colors, shapes, sizes and shadows to your layout.
-                    No configuration or theme is needed, by default it will use MudBlazor's default theme.
+                    The ThemeProvider specifies all the colors, shapes, sizes, and shadows for your layout.
+                    No configuration or theme is needed. By default, it will use MudBlazor's default theme.
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(OverviewThemesDefaultExample)" />
@@ -32,14 +32,14 @@
         
         <DocsPageSection>
             <SectionHeader Title="Scrollbar">
-                <Description>The MudBlazor styled scrollbar can be turned off in the themeprovider with the <CodeInline>DefaultScrollbar</CodeInline> property.</Description>
+                <Description>The MudBlazor styled scrollbar can be turned off in the ThemeProvider with the <CodeInline>DefaultScrollbar</CodeInline> property.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(OverviewThemesScrollbarExample)" />
         </DocsPageSection>
 
         <DocsPageSection>
             <SectionHeader Title="Dark Palette">
-                <Description>Dark palettes are integrated in <CodeInline>MudTheme</CodeInline>. Just set <CodeInline>IsDarkMode</CodeInline> to <CodeInline>true</CodeInline>.</Description>
+                <Description>Dark palettes are integrated into <CodeInline>MudTheme</CodeInline>. Just set <CodeInline>IsDarkMode</CodeInline> to <CodeInline>true</CodeInline>.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(OverviewThemesDarkPaletteExampleSource)">
                 <OverviewThemesDarkPaletteExample/>
@@ -48,14 +48,14 @@
 
         <DocsPageSection>
             <SectionHeader Title="System preference">
-                <Description>With <CodeInline>GetSystemPreference()</CodeInline> you can get the user defined dark theme preference. Returns <CodeInline>true</CodeInline> if dark mode is preferred.</Description>
+                <Description>With <CodeInline>GetSystemPreference()</CodeInline> you can get the user-defined dark theme preference. Returns <CodeInline>true</CodeInline> if dark mode is preferred.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(OverviewThemesSystemPreferenceExample)"/>
         </DocsPageSection>
 
         <DocsPageSection>
             <SectionHeader Title="Watch system preference">
-                <Description><CodeInline>WatchSystemPreference(Func)</CodeInline> calls Func when the system preferences change. <CodeInline>true</CodeInline> if dark mode is preferred.</Description>
+                <Description><CodeInline>WatchSystemPreference(Func)</CodeInline> calls Func when the system preferences change. It returns <CodeInline>true</CodeInline> if dark mode is preferred.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(OverviewThemesWatchSystemPreferenceExample)"/>
         </DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Features/Colors/ColorsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Colors/ColorsPage.razor
@@ -16,7 +16,7 @@
         <DocsPageSection>
             <SectionHeader Title="Theme Palette Colors">
                 <Description>
-                    Each palette color gets converted to a class with the color as background and its contrast, but also separate classes for only background or text color. The CSS class is bound to the MudBlazor theme and updated if you change the theme dynamicly. <br /><br />
+                    Each palette color gets converted to a class with the color as background and its contrast, but also separate classes for only background or text color. The CSS class is bound to the MudBlazor theme and updated if you change the theme dynamically. <br /><br />
                     You can read more about theming <MudLink Href="/customization/overview">MudBlazor here.</MudLink>
                 </Description>
             </SectionHeader>
@@ -31,7 +31,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="CSharp and Theme colors">
-                        <Description>You can also access the colors with blazor directly like we do in this example.</Description>
+                        <Description>You can also access the colors with Blazor directly like we do in this example.</Description>
                     </SectionHeader>
                     <SectionContent DarkenBackground="true" ShowCode="true" Code="@nameof(ColorsMudBlazorCodeExample)">
                         <ColorsMudBlazorCodeExample />
@@ -59,7 +59,7 @@
 
                 <DocsPageSection>
                     <SectionHeader Title="CSharp and Material colors">
-                        <Description>You can also access the material colors with blazor directly like we did above with the MudBlazor palette colors.</Description>
+                        <Description>You can also access the material colors with Blazor directly like we did above with the MudBlazor palette colors.</Description>
                     </SectionHeader>
                     <SectionContent DarkenBackground="true" ShowCode="true" Code="@nameof(ColorsMaterialCodeExample)">
                         <ColorsMaterialCodeExample/>
@@ -68,7 +68,7 @@
 
                 <DocsPageSection>
                     <SectionHeader Title="List of Material Colors">
-                        <Description>Below is a list of the Material design color palette grouped by primary color</Description>
+                        <Description>Below is a list of the Material Design color palette grouped by primary color.</Description>
                     </SectionHeader>
                     <MudGrid Spacing="8">
                         @foreach (var color in MaterialColors)


### PR DESCRIPTION
## Summary
- fix grammar and capitalization issues in the theming overview documentation
- correct spelling and capitalization in the colors feature page

## Testing
- not run (not needed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913e0504d508328ae92bc06962c6ba0)