### PR TITLE
Popover: use PopoverOptions for transition defaults

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
@@ -48,7 +48,7 @@
     public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipNever;
 
     [Parameter]
-    public double Duration { get; set; } = 251;
+    public double? Duration { get; set; }
 
     [Parameter]
     public bool DropShadow { get; set; } = true;

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -1,4 +1,5 @@
-﻿using Bunit;
+﻿using System;
+using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.UnitTests.TestComponents.Popover;
@@ -18,6 +19,8 @@ namespace MudBlazor.UnitTests.Components
             options.ContainerClass.Should().Be("mud-popover-provider");
             options.FlipMargin.Should().Be(0);
             options.ThrowOnDuplicateProvider.Should().Be(true);
+            options.Delay.Should().Be(TimeSpan.Zero);
+            options.Duration.Should().Be(TimeSpan.FromMilliseconds(251));
         }
 
         //[Test]
@@ -113,7 +116,19 @@ namespace MudBlazor.UnitTests.Components
             popover.TransformOrigin.Should().Be(Origin.TopLeft);
             popover.RelativeWidth.Should().Be(DropdownWidth.Ignore);
             popover.OverflowBehavior.Should().BeNull();
-            popover.Duration.Should().Be(251);
+            popover.Duration.Should().BeNull();
+        }
+
+        [Test]
+        public void MudPopover_DefaultStyles_UsePopoverOptions()
+        {
+            var comp = Context.Render<PopoverPropertyTest>();
+
+            var popoverElement = comp.Find(".test-popover-content").ParentElement;
+            var style = popoverElement.GetAttribute("style");
+
+            style.Should().Contain("transition-duration:251ms");
+            style.Should().Contain("transition-delay:0ms");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -529,6 +529,8 @@ public class ServiceCollectionExtensionsTests
             options.PopoverOptions.Mode = PopoverMode.Default;
             options.PopoverOptions.ModalOverlay = true;
             options.PopoverOptions.OverflowBehavior = OverflowBehavior.FlipNever;
+            options.PopoverOptions.Delay = TimeSpan.FromSeconds(1);
+            options.PopoverOptions.Duration = TimeSpan.FromSeconds(2);
 
             expectedOptions = options;
         });
@@ -595,6 +597,8 @@ public class ServiceCollectionExtensionsTests
         actualPopoverOptions.Mode.Should().Be(expectedOptions.PopoverOptions.Mode);
         actualPopoverOptions.ModalOverlay.Should().Be(expectedOptions.PopoverOptions.ModalOverlay);
         actualPopoverOptions.OverflowBehavior.Should().Be(expectedOptions.PopoverOptions.OverflowBehavior);
+        actualPopoverOptions.Delay.Should().Be(expectedOptions.PopoverOptions.Delay);
+        actualPopoverOptions.Duration.Should().Be(expectedOptions.PopoverOptions.Duration);
 
         actualResizeObserverOptions.EnableLogging.Should().Be(expectedOptions.ResizeObserverOptions.EnableLogging);
         actualResizeObserverOptions.ReportRate.Should().Be(expectedOptions.ResizeObserverOptions.ReportRate);

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -109,7 +109,7 @@
                 RelativeWidth="@RelativeWidth"
                 Fixed="@PopoverFixed"
                 DropShadow="@DropShadow"
-                Duration="@(GetDense() ? 0 : MudGlobal.TransitionDefaults.Duration.TotalMilliseconds)">
+                Duration="@GetTransitionDuration()">
         <CascadingValue Value="@this">
             <div id="@_elementId"
                  data-testid="menu-wrapper"

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -364,6 +364,11 @@ namespace MudBlazor
         protected bool GetModal() => Modal ?? PopoverService.PopoverOptions.ModalOverlay;
 
         /// <summary>
+        /// Gets the transition duration for the popover, using dense menus to disable animations.
+        /// </summary>
+        protected double GetTransitionDuration() => GetDense() ? 0 : PopoverService.PopoverOptions.Duration.TotalMilliseconds;
+
+        /// <summary>
         /// The <see cref="MudMenuItem" /> components within this menu.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -53,8 +53,8 @@ namespace MudBlazor
 
         protected string PickerPaperStylename =>
             new StyleBuilder()
-                .AddStyle("transition-duration", $"{Math.Round(MudGlobal.TransitionDefaults.Duration.TotalMilliseconds)}ms")
-                .AddStyle("transition-delay", $"{Math.Round(MudGlobal.TransitionDefaults.Delay.TotalMilliseconds)}ms")
+                .AddStyle("transition-duration", $"{Math.Round(PopoverService.PopoverOptions.Duration.TotalMilliseconds)}ms")
+                .AddStyle("transition-delay", $"{Math.Round(PopoverService.PopoverOptions.Delay.TotalMilliseconds)}ms")
                 .AddStyle(Style)
                 .Build();
 

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -31,8 +31,8 @@ namespace MudBlazor
 
         protected internal override string PopoverStyles =>
             new StyleBuilder()
-                .AddStyle("transition-duration", $"{Duration}ms")
-                .AddStyle("transition-delay", $"{Delay}ms")
+                .AddStyle("transition-duration", $"{GetDuration()}ms")
+                .AddStyle("transition-delay", $"{GetDelay()}ms")
                 .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
                 .AddStyle(Style)
                 .Build();
@@ -118,21 +118,21 @@ namespace MudBlazor
         /// The length of time that the opening transition takes to complete.
         /// </summary>
         /// <remarks>
-        /// Defaults to 251ms in <see cref="MudGlobal.TransitionDefaults.Duration"/>.
+        /// Defaults to <see cref="PopoverOptions.Duration"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public double Duration { get; set; } = MudGlobal.TransitionDefaults.Duration.TotalMilliseconds;
+        public double? Duration { get; set; }
 
         /// <summary>
         /// The amount of time, in milliseconds, from opening the popover to beginning the transition. 
         /// </summary>
         /// <remarks>
-        /// Defaults to 0ms in <see cref="MudGlobal.TransitionDefaults.Delay"/>.
+        /// Defaults to <see cref="PopoverOptions.Delay"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public double Delay { get; set; } = MudGlobal.TransitionDefaults.Delay.TotalMilliseconds;
+        public double? Delay { get; set; }
 
         /// <summary>
         /// The location this popover will appear relative to its parent container.
@@ -168,6 +168,16 @@ namespace MudBlazor
         /// Gets the resolved overflow behavior, using the global default from <see cref="PopoverOptions"/> if not explicitly set.
         /// </summary>
         protected OverflowBehavior GetOverflowBehavior() => OverflowBehavior ?? PopoverService.PopoverOptions.OverflowBehavior;
+
+        /// <summary>
+        /// Gets the resolved transition duration in milliseconds, using the global default from <see cref="PopoverOptions"/> if not explicitly set.
+        /// </summary>
+        protected double GetDuration() => Duration ?? PopoverService.PopoverOptions.Duration.TotalMilliseconds;
+
+        /// <summary>
+        /// Gets the resolved transition delay in milliseconds, using the global default from <see cref="PopoverOptions"/> if not explicitly set.
+        /// </summary>
+        protected double GetDelay() => Delay ?? PopoverService.PopoverOptions.Delay.TotalMilliseconds;
 
         /// <summary>
         /// Determines the width of this popover in relation the parent container.

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -413,6 +413,8 @@ namespace MudBlazor.Services
                     popoverOptions.OverflowPadding = options.PopoverOptions.OverflowPadding;
                     popoverOptions.ModalOverlay = options.PopoverOptions.ModalOverlay;
                     popoverOptions.OverflowBehavior = options.PopoverOptions.OverflowBehavior;
+                    popoverOptions.Delay = options.PopoverOptions.Delay;
+                    popoverOptions.Duration = options.PopoverOptions.Duration;
                 })
                 .AddMudBlazorScrollSpy()
                 .AddMudEventManager()

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -39,28 +39,10 @@ public static class MudGlobal
         /// <summary>
         /// The amount of time in milliseconds to wait from opening the <see cref="MudTooltip"/> before beginning to perform the transition.
         /// </summary>
-        public static TimeSpan Delay { get; set; } = TransitionDefaults.Delay;
-
-        /// <summary>
-        /// The length of time that the opening transition for <see cref="MudTooltip"/> takes to complete.
-        /// </summary>
-        public static TimeSpan Duration { get; set; } = TransitionDefaults.Duration;
-    }
-
-    /// <summary>
-    /// Default settings for transitions in MudBlazor components.
-    /// <br/>
-    /// <b>Warning:</b> This feature is under development and breaking changes to the API <b>will occur</b> between releases.
-    /// </summary>
-    public static class TransitionDefaults
-    {
-        /// <summary>
-        /// The length of time that the opening transition takes to complete.
-        /// </summary>
         public static TimeSpan Delay { get; set; } = TimeSpan.Zero;
 
         /// <summary>
-        /// The amount of time in milliseconds to wait from opening the popover before beginning to perform the transition.
+        /// The length of time that the opening transition for <see cref="MudTooltip"/> takes to complete.
         /// </summary>
         public static TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(251);
     }

--- a/src/MudBlazor/Services/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Services/Popover/PopoverOptions.cs
@@ -11,6 +11,18 @@ namespace MudBlazor;
 public class PopoverOptions
 {
     /// <summary>
+    /// Gets or sets the amount of time in milliseconds to wait from opening the popover before beginning to perform the transition.
+    /// The default value is <c>0</c>.
+    /// </summary>
+    public TimeSpan Delay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Gets or sets the length of time that the opening transition takes to complete.
+    /// The default value is <c>251 milliseconds</c>.
+    /// </summary>
+    public TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(251);
+
+    /// <summary>
     /// Gets or sets a value indicating whether to check for the presence of a popover provider <see cref="MudPopoverProvider"/>.
     /// The default value is <c>true</c>.
     /// </summary>


### PR DESCRIPTION
## Summary
- move transition transition settings into PopoverOptions and remove MudGlobal.TransitionDefaults
- resolve popover transition defaults through injected PopoverOptions across popover-based components
- update service configuration and tests for the new transition option defaults

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944530166a08328929ac3367720413e)