### PR TITLE
Simplify enabled index collection in Autocomplete

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -770,8 +770,16 @@ namespace MudBlazor
 
             _items = searchedItems;
 
-            var enabledItems = _items.Select((item, idx) => (item, idx)).Where(tuple => ItemDisabledFunc?.Invoke(tuple.item) != true).ToList();
-            _enabledItemIndices = enabledItems.Select(tuple => tuple.idx).ToList();
+            var enabledItemIndices = new List<int>(_items.Length);
+            for (var i = 0; i < _items.Length; i++)
+            {
+                if (ItemDisabledFunc?.Invoke(_items[i]) != true)
+                {
+                    enabledItemIndices.Add(i);
+                }
+            }
+
+            _enabledItemIndices = enabledItemIndices;
             if (searchingWhileSelected) //compute the index of the currently select value, if it exists
             {
                 _selectedListItemIndex = Array.IndexOf(_items, ReadValue);


### PR DESCRIPTION
### Motivation

- Reduce allocations and intermediate projections when computing enabled item indices for the autocomplete component.
- Make the logic a single pass over `_items` to improve clarity and performance while keeping behavior identical.
- Preserve existing selection behavior when `ItemDisabledFunc` is `null` and when `searchingWhileSelected` is used.

### Description

- Replaced the tuple-based LINQ projection (`Select((item, idx) => (item, idx)).Where(...)`) with a single `for` loop that builds a `List<int>` of enabled indices.
- Pre-sized the list with `_items.Length` and added index `i` when `ItemDisabledFunc?.Invoke(_items[i]) != true`.
- Assigned the new list to `_enabledItemIndices` and left the `_selectedListItemIndex` computation unchanged (still uses `Array.IndexOf` when `searchingWhileSelected` and chooses the first enabled index otherwise).
- Change localized to `src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs` and preserves previous semantics.

### Testing

- Attempted to run code formatting with `dotnet format src/MudBlazor/MudBlazor.csproj --include src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs`, which failed because `dotnet` is not available in the environment.
- No automated unit tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964389fff948328be0047bd8e023f43)