### PR TITLE
Optimize autocomplete search slicing and enabled-item index collection

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -737,6 +737,9 @@ namespace MudBlazor
 
             if (MaxItems.HasValue)
             {
+                int startIndex = 0;
+                int length = Math.Min(MaxItems.Value, searchedItems.Length);
+
                 // Get range of items based off selected item so the selected item can be scrolled to when strict is set to false
                 if (!Strict && searchedItems.Length != 0 && !EqualityComparer<T>.Default.Equals(ReadValue, default(T)))
                 {
@@ -745,7 +748,7 @@ namespace MudBlazor
 
                     // Center the selected item in the list if possible
                     int half = maxItems / 2;
-                    int startIndex = valueIndex - half;
+                    startIndex = valueIndex - half;
                     int endIndex = startIndex + maxItems;
 
                     // Adjust if out of bounds
@@ -760,30 +763,22 @@ namespace MudBlazor
                         startIndex = Math.Max(0, endIndex - maxItems);
                     }
 
-                    int length = endIndex - startIndex;
-                    if (length < searchedItems.Length)
-                    {
-                        var slicedItems = new T[length];
-                        Array.Copy(searchedItems, startIndex, slicedItems, 0, length);
-                        searchedItems = slicedItems;
-                    }
+                    length = endIndex - startIndex;
                 }
-                else
+
+                if (length < searchedItems.Length)
                 {
-                    int length = Math.Min(MaxItems.Value, searchedItems.Length);
-                    if (length < searchedItems.Length)
-                    {
-                        var slicedItems = new T[length];
-                        Array.Copy(searchedItems, 0, slicedItems, 0, length);
-                        searchedItems = slicedItems;
-                    }
+                    var slicedItems = new T[length];
+                    Array.Copy(searchedItems, startIndex, slicedItems, 0, length);
+                    searchedItems = slicedItems;
                 }
             }
 
             _items = searchedItems;
 
             var enabledItemIndices = new List<int>(_items.Length);
-            if (ItemDisabledFunc is null)
+            var itemDisabledFunc = ItemDisabledFunc;
+            if (itemDisabledFunc is null)
             {
                 for (int i = 0; i < _items.Length; i++)
                 {
@@ -794,7 +789,7 @@ namespace MudBlazor
             {
                 for (int i = 0; i < _items.Length; i++)
                 {
-                    if (!ItemDisabledFunc(_items[i]))
+                    if (!itemDisabledFunc(_items[i]))
                     {
                         enabledItemIndices.Add(i);
                     }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -760,18 +760,48 @@ namespace MudBlazor
                         startIndex = Math.Max(0, endIndex - maxItems);
                     }
 
-                    searchedItems = searchedItems.Take(new Range(startIndex, endIndex)).ToArray();
+                    int length = endIndex - startIndex;
+                    if (length < searchedItems.Length)
+                    {
+                        var slicedItems = new T[length];
+                        Array.Copy(searchedItems, startIndex, slicedItems, 0, length);
+                        searchedItems = slicedItems;
+                    }
                 }
                 else
                 {
-                    searchedItems = searchedItems.Take(MaxItems.Value).ToArray();
+                    int length = Math.Min(MaxItems.Value, searchedItems.Length);
+                    if (length < searchedItems.Length)
+                    {
+                        var slicedItems = new T[length];
+                        Array.Copy(searchedItems, 0, slicedItems, 0, length);
+                        searchedItems = slicedItems;
+                    }
                 }
             }
 
             _items = searchedItems;
 
-            var enabledItems = _items.Select((item, idx) => (item, idx)).Where(tuple => ItemDisabledFunc?.Invoke(tuple.item) != true).ToList();
-            _enabledItemIndices = enabledItems.Select(tuple => tuple.idx).ToList();
+            var enabledItemIndices = new List<int>(_items.Length);
+            if (ItemDisabledFunc is null)
+            {
+                for (int i = 0; i < _items.Length; i++)
+                {
+                    enabledItemIndices.Add(i);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < _items.Length; i++)
+                {
+                    if (!ItemDisabledFunc(_items[i]))
+                    {
+                        enabledItemIndices.Add(i);
+                    }
+                }
+            }
+
+            _enabledItemIndices = enabledItemIndices;
             if (searchingWhileSelected) //compute the index of the currently select value, if it exists
             {
                 _selectedListItemIndex = Array.IndexOf(_items, ReadValue);

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -777,22 +777,11 @@ namespace MudBlazor
             _items = searchedItems;
 
             var enabledItemIndices = new List<int>(_items.Length);
-            var itemDisabledFunc = ItemDisabledFunc;
-            if (itemDisabledFunc is null)
+            for (int i = 0; i < _items.Length; i++)
             {
-                for (int i = 0; i < _items.Length; i++)
+                if (ItemDisabledFunc?.Invoke(_items[i]) != true)
                 {
                     enabledItemIndices.Add(i);
-                }
-            }
-            else
-            {
-                for (int i = 0; i < _items.Length; i++)
-                {
-                    if (!itemDisabledFunc(_items[i]))
-                    {
-                        enabledItemIndices.Add(i);
-                    }
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Reduce unnecessary allocations during autocomplete searches by avoiding `Take(...).ToArray()` when possible.  
- Improve performance of enabled-item index computation by removing LINQ tuple pipeline in hot code paths.  
- Preserve existing public/private behavior: `_items` remains a `T[]` and `_enabledItemIndices` remains a `List<int>` to avoid behavioral changes.  

### Description
- Replace `searchedItems.Take(...).ToArray()` slicing with an `Array.Copy` into a new `T[]` only when the requested subset length is smaller than the original array.  
- For the centered-range case, compute `length = endIndex - startIndex` and copy only when `length < searchedItems.Length`.  
- Replace the LINQ `Select/Where/ToList` tuple pipeline with a single `for` loop that preallocates `new List<int>(_items.Length)` and adds indices when `ItemDisabledFunc` allows.  
- Keep `_items` as an array and assign the new `List<int>` to `_enabledItemIndices`, preserving selection logic and behavior.  

### Testing
- Attempted to run code formatting with `dotnet format src/MudBlazor/MudBlazor.csproj --include src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs` but the `dotnet` command was not available in the environment.  
- No automated unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964389bc4488328899fe6a23b2b3fe0)