### PR TITLE
Add InputSizing.Fill mode for inputs

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldMultilineExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldMultilineExample.razor
@@ -41,24 +41,23 @@
     <MudItem xs="12" md="4">
         <MudStack Spacing="4">
             <MudText Typo="Typo.h6">Fill Sizing</MudText>
-            <MudPaper Class="pa-4" Style="height: 240px;">
-                <MudTextField T="string"
-                              Label="Fill (3 to 8 lines)"
-                              Variant="Variant.Outlined"
-                              Lines="3"
-                              MaxLines="8"
-                              Sizing="InputSizing.Fill"
-                              Placeholder="Fills the container height." />
-            </MudPaper>
-            <MudPaper Class="pa-4" Style="height: 200px;">
-                <MudTextField T="string"
-                              Label="Fill (min 2, max 4)"
-                              Variant="Variant.Filled"
-                              Lines="2"
-                              MaxLines="4"
-                              Sizing="InputSizing.Fill"
-                              Placeholder="Stops early with MaxLines." />
-            </MudPaper>
+            <MudTextField T="string"
+                          Label="Fill (3 to 8 lines)"
+                          Variant="Variant.Outlined"
+                          Lines="3"
+                          MaxLines="8"
+                          Sizing="InputSizing.Fill"
+                          Style="height: 240px;"
+                          Placeholder="Fills the container height." />
+
+            <MudTextField T="string"
+                          Label="Fill (min 2, max 4)"
+                          Variant="Variant.Filled"
+                          Lines="2"
+                          MaxLines="4"
+                          Sizing="InputSizing.Fill"
+                          Style="height: 200px;"
+                          Placeholder="Stops early with MaxLines." />
         </MudStack>
     </MudItem>
 </MudGrid>

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldMultilineExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldMultilineExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudGrid>
-    <MudItem xs="12" sm="6">
+    <MudItem xs="12" md="4">
         <MudStack Spacing="4">
             <MudText Typo="Typo.h6">Fixed Sizing</MudText>
             <MudTextField T="string"
@@ -19,7 +19,7 @@
                           Text="@_fixedText2" />
         </MudStack>
     </MudItem>
-    <MudItem xs="12" sm="6">
+    <MudItem xs="12" md="4">
         <MudStack Spacing="4">
             <MudText Typo="Typo.h6">Auto Sizing</MudText>
             <MudTextField T="string"
@@ -36,6 +36,29 @@
                           MaxLines="10"
                           Sizing="InputSizing.Auto"
                           Placeholder="This one starts small but can grow large." />
+        </MudStack>
+    </MudItem>
+    <MudItem xs="12" md="4">
+        <MudStack Spacing="4">
+            <MudText Typo="Typo.h6">Fill Sizing</MudText>
+            <MudPaper Class="pa-4" Style="height: 240px;">
+                <MudTextField T="string"
+                              Label="Fill (3 to 8 lines)"
+                              Variant="Variant.Outlined"
+                              Lines="3"
+                              MaxLines="8"
+                              Sizing="InputSizing.Fill"
+                              Placeholder="Fills the container height." />
+            </MudPaper>
+            <MudPaper Class="pa-4" Style="height: 200px;">
+                <MudTextField T="string"
+                              Label="Fill (min 2, max 4)"
+                              Variant="Variant.Filled"
+                              Lines="2"
+                              MaxLines="4"
+                              Sizing="InputSizing.Fill"
+                              Placeholder="Stops early with MaxLines." />
+            </MudPaper>
         </MudStack>
     </MudItem>
 </MudGrid>

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -234,7 +234,8 @@
     <SectionHeader Title="Multiline">
         <Description>
             Text fields can be expanded to accommodate multiple lines of text by setting the <CodeInline>Lines</CodeInline> property.
-            Use <CodeInline>Sizing</CodeInline> to control whether the field grows with content.
+            Use <CodeInline>Sizing</CodeInline> to control whether the field grows with content or fills its available height.
+            <CodeInline>InputSizing.Fill</CodeInline> uses <CodeInline>Lines</CodeInline> as a minimum and <CodeInline>MaxLines</CodeInline> to cap the fill height.
         </Description>
     </SectionHeader>
     <SectionContent Code="@nameof(TextFieldMultilineExample)" ShowCode="false">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldAutoSizingDialogLauncherTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldAutoSizingDialogLauncherTest.razor
@@ -13,6 +13,10 @@
             Open Auto Dialog
         </MudButton>
 
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OpenFillDialogAsync">
+            Open Fill Dialog
+        </MudButton>
+
         <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="OpenFixedDialogAsync">
             Open Fixed Dialog
         </MudButton>
@@ -84,6 +88,29 @@
         };
 
         var dialog = await DialogService.ShowAsync<TextFieldFixedSizingDialog>("Edit note (Fixed)", parameters, options);
+        await HandleDialogResult(dialog);
+    }
+
+    private async Task OpenFillDialogAsync()
+    {
+        _lastResult = null;
+        _lastCanceled = false;
+
+        var parameters = new DialogParameters<TextFieldFillSizingDialog>
+        {
+            { x => x.Title, "Edit note (Fill)" },
+            { x => x.Placeholder, "What's on your mind?" },
+            { x => x.InitialText, "Line 1\nLine 2\nLine 3" }
+        };
+
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            FullWidth = true,
+            MaxWidth = MaxWidth.Small
+        };
+
+        var dialog = await DialogService.ShowAsync<TextFieldFillSizingDialog>("Edit note (Fill)", parameters, options);
         await HandleDialogResult(dialog);
     }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldAutoSizingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldAutoSizingTest.razor
@@ -8,6 +8,16 @@
     <MudTextField T="string" Label="example" Variant="Variant.Filled" Sizing="InputSizing.Auto" />
 </div>
 
+<div Style="margin-top:50px;height:200px">
+    Filled with Sizing.Fill
+    <MudTextField T="string"
+                  Label="example"
+                  Variant="Variant.Filled"
+                  Lines="3"
+                  MaxLines="6"
+                  Sizing="InputSizing.Fill" />
+</div>
+
 <div Style="margin-top:50px">
     Filled, Dense with Sizing.Fixed (default)
     <MudTextField T="string" Label="example" Margin="Margin.Dense" Variant="Variant.Filled" Sizing="InputSizing.Fixed" />
@@ -31,6 +41,16 @@
 <div Style="margin-top:50px">
     Outlined with Sizing.Auto
     <MudTextField T="string" Label="example" Variant="Variant.Outlined" Sizing="InputSizing.Auto" />
+</div>
+
+<div Style="margin-top:50px;height:200px">
+    Outlined with Sizing.Fill
+    <MudTextField T="string"
+                  Label="example"
+                  Variant="Variant.Outlined"
+                  Lines="2"
+                  MaxLines="5"
+                  Sizing="InputSizing.Fill" />
 </div>
 
 <div Style="margin-top:50px">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldFillSizingDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldFillSizingDialog.razor
@@ -1,0 +1,70 @@
+@namespace MudBlazor.UnitTests.TestComponents.TextField
+@using MudBlazor
+
+<MudDialog DefaultFocus="DefaultFocus.FirstChild" OnBackdropClick="Submit">
+    <TitleContent>
+        <MudText Typo="Typo.h6">@Title</MudText>
+    </TitleContent>
+
+    <DialogContent Style="display: flex; height: 60vh;">
+        <MudTextField T="string"
+                      @bind-Value="_text"
+                      Typo="Typo.body2"
+                      Placeholder="@Placeholder"
+                      Sizing="InputSizing.Fill"
+                      Underline="false"
+                      FullWidth="true"
+                      Style="height: 100%;"
+                      Immediate />
+    </DialogContent>
+
+    <DialogActions>
+        <MudButton Class="cancel-button"
+                   StartIcon="@Icons.Material.Rounded.Close"
+                   AriaLabel="Cancel"
+                   OnClick="Cancel">
+            Cancel
+        </MudButton>
+
+        <MudButton Class="submit-button"
+                   StartIcon="@Icons.Material.Rounded.Check"
+                   AriaLabel="Submit"
+                   OnClick="Submit"
+                   Variant="Variant.Filled"
+                   Color="Color.Primary">
+            Submit
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private bool _initialized;
+    private string _text = string.Empty;
+
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter]
+    public string Title { get; set; } = "Edit note (Fill)";
+
+    [Parameter]
+    public string Placeholder { get; set; } = "Type here";
+
+    [Parameter]
+    public string? InitialText { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _initialized = true;
+        _text = InitialText ?? string.Empty;
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void Submit() => MudDialog.Close(DialogResult.Ok(_text));
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldFillSizingDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldFillSizingDialog.razor
@@ -6,7 +6,7 @@
         <MudText Typo="Typo.h6">@Title</MudText>
     </TitleContent>
 
-    <DialogContent Style="display: flex; height: 60vh;">
+    <DialogContent>
         <MudTextField T="string"
                       @bind-Value="_text"
                       Typo="Typo.body2"

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -23,6 +23,7 @@ public class InputTests : BunitTest
     }
 
     [TestCase(InputSizing.Auto, "mud-input-sizing-auto")]
+    [TestCase(InputSizing.Fill, "mud-input-sizing-fill")]
     [TestCase(InputSizing.Fixed, "mud-input-sizing-fixed")]
     public void InputSizingHasClass(InputSizing sizing, string expectedClass)
     {

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -430,9 +430,11 @@ namespace MudBlazor.UnitTests.Components
             Context.JSInterop.Invocations["mudInputSizing.init"].Single()
                 .Arguments
                 .Should()
-                .HaveCount(2)
+                .HaveCount(3)
                 .And
-                .HaveElementAt(1, 5); // MaxLines
+                .HaveElementAt(1, 5) // MaxLines
+                .And
+                .HaveElementAt(2, "auto");
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Value, "A"));
 
@@ -440,6 +442,24 @@ namespace MudBlazor.UnitTests.Components
                 .Arguments
                 .Should()
                 .HaveCount(1);
+        }
+
+        [Test]
+        public void FillSizingTextField_Should_InvokeJavaScriptInitOnRender()
+        {
+            Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Sizing, InputSizing.Fill)
+                .Add(p => p.MaxLines, 4));
+
+            Context.JSInterop.VerifyInvoke("mudInputSizing.init", 1);
+            Context.JSInterop.Invocations["mudInputSizing.init"].Single()
+                .Arguments
+                .Should()
+                .HaveCount(3)
+                .And
+                .HaveElementAt(1, 4) // MaxLines
+                .And
+                .HaveElementAt(2, "fill");
         }
 
         [Test]
@@ -1123,6 +1143,7 @@ namespace MudBlazor.UnitTests.Components
         /// A text field with sizing enabled should contain the correct sizing class.
         /// </summary>
         [TestCase(InputSizing.Auto, "mud-input-sizing-auto")]
+        [TestCase(InputSizing.Fill, "mud-input-sizing-fill")]
         [TestCase(InputSizing.Fixed, "mud-input-sizing-fixed")]
         public void TextFieldSizingHasClass(InputSizing sizing, string expectedClass)
         {

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -164,7 +164,7 @@ namespace MudBlazor
         public InputSizing Sizing { get; set; } = InputSizing.Fixed;
 
         /// <summary>
-        /// The maximum vertical lines to display when <see cref="Sizing"/> is <see cref="InputSizing.Auto"/>.
+        /// The maximum vertical lines to display when <see cref="Sizing"/> is <see cref="InputSizing.Auto"/> or <see cref="InputSizing.Fill"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>0</c>.  When <c>0</c>. this property is ignored.
@@ -308,7 +308,7 @@ namespace MudBlazor
                     if (newSizing != InputSizing.Fixed && !_shouldInitSizing)
                     {
                         // Update dynamic sizing parameters (if it was already enabled).
-                        await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputSizing.updateParams", ElementReference, MaxLines);
+                        await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputSizing.updateParams", ElementReference, MaxLines, Sizing.ToDescriptionString());
                     }
                 }
             }
@@ -324,7 +324,7 @@ namespace MudBlazor
                 if (firstRender || _shouldInitSizing)
                 {
                     _shouldInitSizing = false;
-                    await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputSizing.init", ElementReference, MaxLines);
+                    await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInputSizing.init", ElementReference, MaxLines, Sizing.ToDescriptionString());
                     _oldText = _internalText;
                 }
                 else if (_oldText != _internalText)

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -91,7 +91,7 @@ namespace MudBlazor
         public InputSizing Sizing { get; set; } = InputSizing.Fixed;
 
         /// <summary>
-        /// The maximum vertical lines to display when <see cref="Sizing"/> is <see cref="InputSizing.Auto"/>.
+        /// The maximum vertical lines to display when <see cref="Sizing"/> is <see cref="InputSizing.Auto"/> or <see cref="InputSizing.Fill"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>0</c>.  When <c>0</c>. this property is ignored.

--- a/src/MudBlazor/Enums/InputSizing.cs
+++ b/src/MudBlazor/Enums/InputSizing.cs
@@ -26,4 +26,11 @@ public enum InputSizing
     /// </remarks>
     [Description("auto")]
     Auto,
+
+    /// <summary>
+    /// The height fills the available container space.
+    /// Uses Lines as minimum and MaxLines as maximum.
+    /// </summary>
+    [Description("fill")]
+    Fill,
 }

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -215,6 +215,18 @@
   }
 }
 
+.mud-input.mud-input-sizing-fill {
+  height: 100%;
+
+  > .mud-input-root {
+    height: 100%;
+  }
+
+  > textarea.mud-input-root {
+    height: 100%;
+  }
+}
+
 .mud-input-error .mud-input-outlined-border {
   border-color: var(--mud-palette-error) !important;
 }

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -164,6 +164,15 @@
   }
 }
 
+.mud-input-control.mud-input-sizing-fill {
+  height: 100%;
+
+  > .mud-input-control-input-container {
+    flex: 1 1 auto;
+    height: 100%;
+  }
+}
+
 .mud-input-control-helper-container {
   overflow: hidden;
   margin-top: 3px;

--- a/src/MudBlazor/TScripts/mudInputSizing.js
+++ b/src/MudBlazor/TScripts/mudInputSizing.js
@@ -3,20 +3,27 @@
 // See the LICENSE file in the project root for more information.
 
 window.mudInputSizing = {
-    init: (elem, maxLines) => {
+    init: (elem, maxLines, sizing) => {
         const compStyle = getComputedStyle(elem);
         const lineHeight = parseFloat(compStyle.getPropertyValue('line-height'));
         const paddingTop = parseFloat(compStyle.getPropertyValue('padding-top'));
+        const marginTop = parseFloat(compStyle.getPropertyValue('margin-top'));
+        const marginBottom = parseFloat(compStyle.getPropertyValue('margin-bottom'));
 
         let maxHeight = 0;
+        let sizingMode = sizing ?? 'auto';
 
         // Update parameters that affect the functionality and visuals of the sizing input.
-        elem.updateParameters = function (newMaxLines) {
+        elem.updateParameters = function (newMaxLines, newSizing) {
             if (newMaxLines > 0) {
                 // Cap the height to the number of lines specified in the input.
                 maxHeight = lineHeight * newMaxLines + paddingTop;
             } else {
                 maxHeight = 0;
+            }
+
+            if (newSizing) {
+                sizingMode = newSizing;
             }
         }
 
@@ -30,6 +37,33 @@ window.mudInputSizing = {
                     scrollTops.push([curElem.parentNode, curElem.parentNode.scrollTop]);
                 }
                 curElem = curElem.parentNode;
+            }
+
+            if (sizingMode === 'fill') {
+                const container = elem.closest('.mud-input') ?? elem.parentElement;
+                const containerHeight = container ? container.clientHeight : 0;
+                const minHeight = lineHeight * elem.rows + paddingTop;
+                const availableHeight = containerHeight > 0
+                    ? containerHeight - marginTop - marginBottom
+                    : minHeight;
+                let newHeight = Math.max(minHeight, availableHeight);
+
+                if (maxHeight > 0) {
+                    newHeight = Math.min(newHeight, maxHeight);
+                }
+
+                newHeight = Math.max(newHeight, minHeight);
+
+                elem.style.height = newHeight + "px";
+                elem.style.overflowY = elem.scrollHeight > newHeight ? 'auto' : 'hidden';
+
+                // Restore scroll positions.
+                scrollTops.forEach(([node, scrollTop]) => {
+                    node.style.scrollBehavior = 'auto';
+                    node.scrollTop = scrollTop;
+                    node.style.scrollBehavior = null;
+                });
+                return;
             }
 
             // Auto mode - grow/shrink based on content
@@ -82,7 +116,7 @@ window.mudInputSizing = {
         window.addEventListener('resize', elem.adjustSizingHeight);
 
         // Initial parameters and height adjustment.
-        elem.updateParameters(maxLines);
+        elem.updateParameters(maxLines, sizingMode);
         elem.adjustSizingHeight();
     },
     adjustHeight: (elem) => {
@@ -90,9 +124,9 @@ window.mudInputSizing = {
             elem.adjustSizingHeight();
         }
     },
-    updateParams: (elem, maxLines) => {
+    updateParams: (elem, maxLines, sizing) => {
         if (typeof elem.updateParameters === 'function') {
-            elem.updateParameters(maxLines);
+            elem.updateParameters(maxLines, sizing);
         }
         if (typeof elem.adjustSizingHeight === 'function') {
             elem.adjustSizingHeight();

--- a/src/MudBlazor/TScripts/mudInputSizing.js
+++ b/src/MudBlazor/TScripts/mudInputSizing.js
@@ -11,7 +11,7 @@ window.mudInputSizing = {
         const marginBottom = parseFloat(compStyle.getPropertyValue('margin-bottom'));
 
         let maxHeight = 0;
-        let sizingMode = sizing ?? 'auto';
+        let sizingMode = sizing || 'auto';
 
         // Update parameters that affect the functionality and visuals of the sizing input.
         elem.updateParameters = function (newMaxLines, newSizing) {
@@ -40,7 +40,7 @@ window.mudInputSizing = {
             }
 
             if (sizingMode === 'fill') {
-                const container = elem.closest('.mud-input') ?? elem.parentElement;
+                const container = elem.closest('.mud-input') || elem.parentElement;
                 const containerHeight = container ? container.clientHeight : 0;
                 const minHeight = lineHeight * elem.rows + paddingTop;
                 const availableHeight = containerHeight > 0


### PR DESCRIPTION
### Motivation
- Provide a new sizing mode that stretches multiline inputs to fill the available container height while preserving `Lines` as a minimum and using `MaxLines` to cap the filled height.
- Reuse the existing input sizing JS interop but extend it to support a fill strategy and proper overflow handling inside the input element.
- Update docs, examples, test viewer pages and unit tests so the new behavior is documented and covered by tests.

### Description
- Added `InputSizing.Fill` to `src/MudBlazor/Enums/InputSizing.cs` with the description string `"fill"`.
- Wired sizing through JS interop by extending `mudInputSizing.init` and `mudInputSizing.updateParams` to accept a `sizing` argument and added fill-mode logic to `src/MudBlazor/TScripts/mudInputSizing.js` that computes available container height, respects `Lines` and `MaxLines`, sets `height` and `overflowY`, and restores scroll positions.
- Passed the sizing mode string from .NET by updating calls to `mudInputSizing.init` and `mudInputSizing.updateParams` in `src/MudBlazor/Components/Input/MudInput.razor.cs`.
- Added CSS to make fill sizing stretch inputs and input controls via `.mud-input.mud-input-sizing-fill` and `.mud-input-control.mud-input-sizing-fill` in `src/MudBlazor/Styles/components/_input.scss` and `src/MudBlazor/Styles/components/_inputcontrol.scss`.
- Updated documentation and examples in `src/MudBlazor.Docs/Pages/Components/TextField/*` and the unit-test viewer examples to show `InputSizing.Fill` usage.
- Updated unit tests in `src/MudBlazor.UnitTests/Components/*` to expect the new sizing class and that JS interop is invoked with the sizing argument for `Auto` and `Fill` modes.

### Testing
- No automated tests were executed in this environment because `dotnet` was not available to run `dotnet format` or `dotnet test`, so test changes were added but not executed here.
- The JS behavior and styles were updated and exercised in the examples/test viewer sources, but visual/manual verification and unit test execution should be run in CI or a local environment with the .NET SDK available. 
- Please run `dotnet format` for changed files and `dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MudTextField" --no-build -c Release` locally or in CI to validate the unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696715eb50648328adc9c743ce17aae8)