### PR TITLE
Use Find for single-element assertions in tests

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
@@ -208,7 +208,7 @@ public class RadarChartTests : BunitTest
         );
 
         // Simulate click on the first series path (index 0)
-        await comp.FindAll("path.mud-chart-serie").First().ClickAsync();
+        await comp.Find("path.mud-chart-serie").ClickAsync();
         selectedIndex.Should().Be(0);
 
         // Simulate click on the second series path (index 1)

--- a/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
@@ -164,7 +164,7 @@ public class RoseChartTests : BunitTest
         );
 
         // Click on the first path segment (index 0)
-        await comp.FindAll("path.mud-chart-serie").First().ClickAsync();
+        await comp.Find("path.mud-chart-serie").ClickAsync();
         selectedIndex.Should().Be(0);
 
         // Click on the third path segment (index 2)

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3415,7 +3415,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<DataGridFooterTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFooterTemplateTest.Model>>();
 
-            dataGrid.FindAll("tfoot td").First().TextContent.Trim().Should().Be("Names: Sam, Alicia, Ira, John");
+            dataGrid.Find("tfoot td").TextContent.Trim().Should().Be("Names: Sam, Alicia, Ira, John");
             dataGrid.FindAll("tfoot td").Last().TextContent.Trim().Should().Be($"Highest: {132000:C0} | 2 Over {100000:C0}");
         }
 

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -106,8 +106,7 @@ namespace MudBlazor.UnitTests.Components
             var panels = comp.FindAll(".mud-panel-expanded").ToList();
             panels.Count.Should().Be(1);
 
-            var header = comp.FindAll(".panel-two > .mud-expand-panel-header").First();
-            await header.ClickAsync();
+            await comp.Find(".panel-two > .mud-expand-panel-header").ClickAsync();
 
             //we could close the panel
             panels = comp.FindAll(".mud-panel-expanded").ToList();

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -668,7 +668,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(1));
 
             // set invalid color
-            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-color-collection>div.mud-picker-color-dot").First().Click());
+            await comp.InvokeAsync(() => comp.Find("div.mud-picker-color-collection>div.mud-picker-color-dot").Click());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(0));
             form.IsTouched.Should().BeTrue();
             form.IsValid.Should().BeFalse();

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -552,17 +552,17 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be(null));
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(null));
             // English
-            await comp.FindAll("input").First().InputAsync("abcd");
-            await comp.FindAll("input").First().BlurAsync();
+            await comp.Find("input").InputAsync("abcd");
+            await comp.Find("input").BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be(null));
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(null));
             // English
-            await comp.FindAll("input").First().InputAsync("-12-34abc.56");
-            await comp.FindAll("input").First().BlurAsync();
+            await comp.Find("input").InputAsync("-12-34abc.56");
+            await comp.Find("input").BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be(null));
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(null));
-            await comp.FindAll("input").First().InputAsync("-1234.56");
-            await comp.FindAll("input").First().BlurAsync();
+            await comp.Find("input").InputAsync("-1234.56");
+            await comp.Find("input").BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be("-1,234.56"));
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(-1234.56));
             await comp.FindAll("input").Last().ChangeAsync("x+17,9y9z");
@@ -580,12 +580,12 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<NumericFieldCultureTest>();
             // english
-            await comp.FindAll("input").First().InputAsync("1,234.56");
-            await comp.FindAll("input").First().BlurAsync();
+            await comp.Find("input").InputAsync("1,234.56");
+            await comp.Find("input").BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be("1,234.56"));
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(1234.56));
-            await comp.FindAll("input").First().InputAsync("1234.56");
-            await comp.FindAll("input").First().BlurAsync();
+            await comp.Find("input").InputAsync("1234.56");
+            await comp.Find("input").BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be("1,234.56"));
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(1234.56));
             // german
@@ -798,8 +798,8 @@ namespace MudBlazor.UnitTests.Components
             };
             conv.Convert(77).Should().Be("€77");
             //
-            await comp.FindAll("input").First().ChangeAsync("1234");
-            await comp.FindAll("input").First().BlurAsync();
+            await comp.Find("input").ChangeAsync("1234");
+            await comp.Find("input").BlurAsync();
             await comp.WaitForAssertionAsync(() => numericField.ReadText.Should().Be("€1234"));
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234));
         }
@@ -818,15 +818,15 @@ namespace MudBlazor.UnitTests.Components
 
             // comma separator
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Culture, CultureInfo.InvariantCulture));
-            await comp.FindAll("input").First().ChangeAsync("1,000");
-            await comp.FindAll("input").First().BlurAsync();
+            await comp.Find("input").ChangeAsync("1,000");
+            await comp.Find("input").BlurAsync();
             await comp.WaitForAssertionAsync(() => numericField.ReadText.Should().Be("1000"));
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1000));
 
             // period separator
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Culture, new CultureInfo("de-DE", false)));
-            await comp.FindAll("input").First().ChangeAsync("1.000");
-            await comp.FindAll("input").First().BlurAsync();
+            await comp.Find("input").ChangeAsync("1.000");
+            await comp.Find("input").BlurAsync();
             await comp.WaitForAssertionAsync(() => numericField.ReadText.Should().Be("1000"));
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1000));
         }
@@ -1237,8 +1237,8 @@ namespace MudBlazor.UnitTests.Components
             var numericField = comp.Instance;
 
             // insert an invalid int number, greater then maximum int value
-            await comp.FindAll("input").First().ChangeAsync("2147483648");
-            await comp.FindAll("input").First().BlurAsync();
+            await comp.Find("input").ChangeAsync("2147483648");
+            await comp.Find("input").BlurAsync();
 
             // conversion is not possible and conversion error is set
             await comp.WaitForAssertionAsync(() =>

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -455,7 +455,7 @@ namespace MudBlazor.UnitTests.Components
             // Test that clicking the close button will actually close the snackbar even with the pointer over.
 
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
-            await _provider.FindAll(".mud-snackbar-close-button").Single().ClickAsync();
+            await _provider.Find(".mud-snackbar-close-button").ClickAsync();
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -482,7 +482,7 @@ namespace MudBlazor.UnitTests.Components
 
             counter.Should().Be(0);
 
-            await _provider.FindAll(".mud-snackbar-close-button").Single().ClickAsync();
+            await _provider.Find(".mud-snackbar-close-button").ClickAsync();
 
             counter.Should().Be(1);
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));


### PR DESCRIPTION
### Motivation

- Align tests with bUnit best practices by using `Find` for single-element existence/interactions and `FindAll` for cardinality checks to avoid stale or ambiguous queries.
- Reduce reliance on LINQ (`First()`, `Single()`) on results of `FindAll(...)` when a single element is intended, improving clarity and intent of the tests.

### Description

- Replaced usages of `FindAll(...).First()` / `FindAll(...).Single()` with `Find(...)` for direct single-element selection and interactions.
- Converted click/change/input/blur calls accordingly to use the `Find(...)` target where appropriate.
- Updated the following test files: `src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs`, `src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs`, `src/MudBlazor.UnitTests/Components/DataGridTests.cs`, `src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs`, `src/MudBlazor.UnitTests/Components/FormTests.cs`, `src/MudBlazor.UnitTests/Components/NumericFieldTests.cs`, and `src/MudBlazor.UnitTests/Components/SnackbarTests.cs`.
- Committed the changes with message `Use Find for single element assertions in tests`.

### Testing

- No automated unit tests were executed in this environment after the changes. 
- Attempted to run `dotnet format` on the modified test files but the `dotnet` tool was not available in the environment, so formatting was not completed (command failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c199dba8c8328aa1a2f6635457c92)