### PR TITLE
Improve docs tests parallel safety and generator efficiency

### DIFF
--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using MudBlazor.Charts;
 
@@ -134,7 +135,7 @@ public partial class TestsForApiPages
     /// <remarks>
     /// This list should match the types mentioned in the <c>MenuService</c> class in MudBlazor.Docs.
     /// </remarks>
-    public List<Type> TypesWithExamples =
+    public static List<Type> TypesWithExamples { get; } =
     [
         typeof(MudContainer), typeof(MudGrid), typeof(MudItem), typeof(MudHidden),  typeof(MudBreakpointProvider), typeof(MudChip<object>), typeof(MudChipSet<object>),
         typeof(MudBadge), typeof(MudAppBar), typeof(MudDrawer), typeof(MudDrawerHeader), typeof(MudDrawerContainer), typeof(MudDropZone<object>), typeof(MudDropContainer<object>),
@@ -156,6 +157,10 @@ public partial class TestsForApiPages
         typeof(MudToggleIconButton), typeof(MudFab), typeof(ChartOptions), typeof(Donut<>), typeof(Line<>), typeof(Legend<>), typeof(Pie<>), typeof(Bar<>), typeof(HeatMap<>),typeof(StackedBar<>),
         typeof(TimeSeries<>), typeof(Radar<>), typeof(Rose<>)
     ];
+
+    private static readonly HashSet<string> TypesWithExamplesLookup = new(
+        TypesWithExamples.Select(type => type.Name),
+        StringComparer.Ordinal);
 
     /// <summary>
     /// Ensures that an API page is available for each MudBlazor component.
@@ -183,6 +188,7 @@ public partial class TestsForApiPages
             cb.AddLine("using MudBlazor.Docs.Pages.Api;");
             cb.AddLine("using MudBlazor.Docs.Services;");
             cb.AddLine("using NUnit.Framework;");
+            cb.AddLine("using System.Threading.Tasks;");
             cb.AddLine();
             cb.AddLine("namespace MudBlazor.UnitTests.Docs.Generated");
             cb.AddLine("{");
@@ -236,7 +242,7 @@ public partial class TestsForApiPages
                 && !type.Name.Contains("Extensions")
                 // ... which aren't clone strategies
                 && !type.Name.Contains("SystemTextJson"))
-            .ToList();
+            .OrderBy(type => type.FullName, StringComparer.Ordinal);
         foreach (var type in mudBlazorComponents)
         {
             // Skip MudBlazor.Color and MudBlazor.Input types
@@ -252,11 +258,11 @@ public partial class TestsForApiPages
             // Create Api.razor with a type
             cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{type.Name}""));");
             cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{type.Name}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
+            cb.AddLine("await WaitForRenderQueueAsync();");
             // Make sure docs for the type were actually found
             cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {type.Name} was not found"");");
             // Should there be a link to the example page?
-            if (TypesWithExamples.Exists(exampleType => exampleType.Name == type.Name))
+            if (TypesWithExamplesLookup.Contains(type.Name))
             {
                 // Yes.  Check for the example link
                 cb.AddLine(@$"var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href != null && link.Instance.Href.StartsWith(""/component""));");
@@ -283,7 +289,7 @@ public partial class TestsForApiPages
             // Create Api.razor with a type
             cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{url}""));");
             cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{component}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
+            cb.AddLine("await WaitForRenderQueueAsync();");
             // Make sure docs for the type were actually found
             cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {component} was not found"");");
             cb.IndentLevel--;

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
@@ -21,6 +21,7 @@ public class TestsForExamples
             cb.AddLine("using MudBlazor.Docs.Examples;");
             cb.AddLine("using MudBlazor.Docs.Wireframes;");
             cb.AddLine("using NUnit.Framework;");
+            cb.AddLine("using System.Threading.Tasks;");
             cb.AddLine();
 
             cb.AddLine("namespace MudBlazor.UnitTests.Docs.Generated");
@@ -45,10 +46,10 @@ public class TestsForExamples
                 if (filename == "TableVirtualizationExample.razor" || filename == "DataGridVirtualizationExample.razor")
                     continue;
                 cb.AddLine("[Test]");
-                cb.AddLine($"public void {componentName}_Test()");
+                cb.AddLine($"public async Task {componentName}_Test()");
                 cb.AddLine("{");
                 cb.IndentLevel++;
-                cb.AddLine($"ctx.Render<{componentName}>();");
+                cb.AddLine($"await RenderExampleAsync<{componentName}>();");
                 cb.IndentLevel--;
                 cb.AddLine("}");
             }

--- a/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
@@ -20,7 +20,6 @@ namespace MudBlazor.UnitTests.Docs.Generated
     {
         private static readonly ServiceDescriptor[] DefaultServices = CreateDefaultServices();
         private BunitContext ctx;
-        private IRenderQueueService renderQueueService;
 
         private static ServiceDescriptor[] CreateDefaultServices()
         {
@@ -60,7 +59,6 @@ namespace MudBlazor.UnitTests.Docs.Generated
             {
                 ctx.Services.Add(descriptor);
             }
-            renderQueueService = ctx.Services.GetRequiredService<IRenderQueueService>();
         }
 
         // This shows how to test a docs page with incremental rendering.
@@ -90,10 +88,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
         [TearDown]
         public async Task TearDown()
         {
-            if (renderQueueService is not null)
-            {
-                await renderQueueService.WaitUntilEmpty();
-            }
+            await WaitForRenderQueueAsync();
 
             if (ctx is not null)
             {
@@ -103,7 +98,8 @@ namespace MudBlazor.UnitTests.Docs.Generated
 
         protected Task WaitForRenderQueueAsync()
         {
-            return renderQueueService.WaitUntilEmpty();
+            var queueService = ctx.Services.GetRequiredService<IRenderQueueService>();
+            return queueService.WaitUntilEmpty();
         }
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
@@ -1,4 +1,7 @@
-﻿using AwesomeAssertions;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,38 +14,53 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Docs.Generated
 {
     [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public partial class ApiDocsTests
     {
-        private Bunit.BunitContext ctx;
+        private static readonly ServiceDescriptor[] DefaultServices = CreateDefaultServices();
+        private BunitContext ctx;
+        private IRenderQueueService renderQueueService;
+
+        private static ServiceDescriptor[] CreateDefaultServices()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(TimeProvider.System);
+            services.AddSingleton<IDialogService, DialogService>();
+            services.AddSingleton<ISnackbar, SnackbarService>();
+            services.AddSingleton<IBrowserViewportService, MockBrowserViewportService>();
+            services.AddTransient<IScrollManager, MockScrollManager>();
+            services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
+            services.AddTransient<IJsApiService, MockJsApiService>();
+            services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
+            services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
+            services.AddTransient<IScrollSpyFactory, MockScrollSpyFactory>();
+            services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
+            services.AddTransient<IEventListener, MockEventListener>();
+            services.AddSingleton<IDocsNavigationService, DocsNavigationService>();
+            services.AddSingleton<IMenuService, MenuService>();
+            services.AddSingleton<IPopoverService, MockPopoverService>();
+            services.AddSingleton<IKeyInterceptorService, MockKeyInterceptorService>();
+            services.AddTransient<IJsEventFactory, MockJsEventFactory>();
+            services.AddScoped<IRenderQueueService, RenderQueueService>();
+            services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
+            services.AddTransient<InternalMudLocalizer>();
+            services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
+            services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
+            services.AddScoped(sp => new HttpClient());
+            return services.ToArray();
+        }
 
         [SetUp]
         public void Setup()
         {
-            ctx = new Bunit.BunitContext();
+            ctx = new BunitContext();
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
-            ctx.Services.AddSingleton(TimeProvider.System);
-            ctx.Services.AddSingleton<IDialogService>(new DialogService());
-            ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
-            ctx.Services.AddSingleton<IBrowserViewportService>(new MockBrowserViewportService());
-            ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
-            ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
-            ctx.Services.AddTransient<IJsApiService, MockJsApiService>();
-            ctx.Services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
-            ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
-            ctx.Services.AddTransient<IScrollSpyFactory, MockScrollSpyFactory>();
-            ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
-            ctx.Services.AddTransient<IEventListener, MockEventListener>();
-            ctx.Services.AddSingleton<IDocsNavigationService, DocsNavigationService>();
-            ctx.Services.AddSingleton<IMenuService, MenuService>();
-            ctx.Services.AddSingleton<IPopoverService, MockPopoverService>();
-            ctx.Services.AddSingleton<IKeyInterceptorService, MockKeyInterceptorService>();
-            ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
-            ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
-            ctx.Services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
-            ctx.Services.AddTransient<InternalMudLocalizer>();
-            ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
-            ctx.Services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
-            ctx.Services.AddScoped(sp => new HttpClient());
+            foreach (var descriptor in DefaultServices)
+            {
+                ctx.Services.Add(descriptor);
+            }
+            renderQueueService = ctx.Services.GetRequiredService<IRenderQueueService>();
         }
 
         // This shows how to test a docs page with incremental rendering.
@@ -52,7 +70,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
         {
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/alert"));
             var comp = ctx.Render<MudBlazor.Docs.Pages.Components.Alert.AlertPage>();
-            await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
+            await WaitForRenderQueueAsync();
         }
 
         /// <summary>
@@ -63,13 +81,29 @@ namespace MudBlazor.UnitTests.Docs.Generated
         {
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/MudAlert"));
             var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, "MudAlert"));
-            await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
+            await WaitForRenderQueueAsync();
             comp.Markup.Should().NotContain("Sorry, the type").And.NotContain("could not be found");
             var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href.StartsWith("/component"));
             exampleLink.Should().NotBeNull();
         }
 
         [TearDown]
-        public async Task TearDown() => await ctx.DisposeAsync();
+        public async Task TearDown()
+        {
+            if (renderQueueService is not null)
+            {
+                await renderQueueService.WaitUntilEmpty();
+            }
+
+            if (ctx is not null)
+            {
+                await ctx.DisposeAsync();
+            }
+        }
+
+        protected Task WaitForRenderQueueAsync()
+        {
+            return renderQueueService.WaitUntilEmpty();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
@@ -19,7 +19,6 @@ namespace MudBlazor.UnitTests.Docs.Generated
     {
         private static readonly ServiceDescriptor[] DefaultServices = CreateDefaultServices();
         private BunitContext ctx;
-        private IRenderQueueService renderQueueService;
 
         private static ServiceDescriptor[] CreateDefaultServices()
         {
@@ -61,16 +60,12 @@ namespace MudBlazor.UnitTests.Docs.Generated
             {
                 ctx.Services.Add(descriptor);
             }
-            renderQueueService = ctx.Services.GetRequiredService<IRenderQueueService>();
         }
 
         [TearDown]
         public async Task TearDown()
         {
-            if (renderQueueService is not null)
-            {
-                await renderQueueService.WaitUntilEmpty();
-            }
+            await WaitForRenderQueueAsync();
 
             if (ctx is not null)
             {
@@ -82,7 +77,13 @@ namespace MudBlazor.UnitTests.Docs.Generated
             where TComponent : IComponent
         {
             ctx.Render<TComponent>();
-            await renderQueueService.WaitUntilEmpty();
+            await WaitForRenderQueueAsync();
+        }
+
+        private Task WaitForRenderQueueAsync()
+        {
+            var queueService = ctx.Services.GetRequiredService<IRenderQueueService>();
+            return queueService.WaitUntilEmpty();
         }
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
@@ -1,4 +1,7 @@
-﻿using Bunit;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Docs.Services;
@@ -10,50 +13,76 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Docs.Generated
 {
     [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public partial class ExampleDocsTests
     {
+        private static readonly ServiceDescriptor[] DefaultServices = CreateDefaultServices();
         private BunitContext ctx;
+        private IRenderQueueService renderQueueService;
+
+        private static ServiceDescriptor[] CreateDefaultServices()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(TimeProvider.System);
+            services.AddSingleton<NavigationManager, MockNavigationManager>();
+            services.AddSingleton<IDialogService, DialogService>();
+            services.AddSingleton<ISnackbar, SnackbarService>();
+            services.AddSingleton<IBrowserViewportService, MockBrowserViewportService>();
+            services.AddTransient<IScrollManager, MockScrollManager>();
+            services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
+            services.AddTransient<IJsApiService, MockJsApiService>();
+            services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
+            services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
+            services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
+            services.AddTransient<IEventListener, MockEventListener>();
+            services.AddSingleton<IKeyInterceptorService, MockKeyInterceptorService>();
+            services.AddTransient<IJsEventFactory, MockJsEventFactory>();
+            services.AddSingleton<IPopoverService, MockPopoverService>();
+            services.AddScoped<IRenderQueueService, RenderQueueService>();
+            services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
+            services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
+            services.AddTransient<InternalMudLocalizer>();
+            services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
+            services.AddTransient<IScrollListener, ScrollListener>();
+            services.AddTransient<IResizeObserver, ResizeObserver>();
+            services.AddOptions();
+            services.AddScoped(sp =>
+                new HttpClient(new MockDocsMessageHandler()) { BaseAddress = new Uri("https://localhost/") });
+            return services.ToArray();
+        }
 
         [SetUp]
         public void Setup()
         {
             ctx = new BunitContext();
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
-            ctx.Services.AddSingleton(TimeProvider.System);
-            ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
-            ctx.Services.AddSingleton<IDialogService>(new DialogService());
-            ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
-            ctx.Services.AddSingleton<IBrowserViewportService>(new MockBrowserViewportService());
-            ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
-            ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
-            ctx.Services.AddTransient<IJsApiService, MockJsApiService>();
-            ctx.Services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
-            ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
-            ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
-            ctx.Services.AddTransient<IEventListener, MockEventListener>();
-            ctx.Services.AddSingleton<IKeyInterceptorService, MockKeyInterceptorService>();
-            ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
-            ctx.Services.AddSingleton<IPopoverService, MockPopoverService>();
-            ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
-            ctx.Services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
-            ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
-            ctx.Services.AddTransient<InternalMudLocalizer>();
-            ctx.Services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
-            ctx.Services.AddTransient<IScrollListener, ScrollListener>();
-            ctx.Services.AddTransient<IResizeObserver, ResizeObserver>();
-            ctx.Services.AddOptions();
-            ctx.Services.AddScoped(sp =>
-                new HttpClient(new MockDocsMessageHandler()) { BaseAddress = new Uri("https://localhost/") });
+            foreach (var descriptor in DefaultServices)
+            {
+                ctx.Services.Add(descriptor);
+            }
+            renderQueueService = ctx.Services.GetRequiredService<IRenderQueueService>();
         }
 
         [TearDown]
-        public void TearDown()
+        public async Task TearDown()
         {
-            try
+            if (renderQueueService is not null)
             {
-                ctx.Dispose();
+                await renderQueueService.WaitUntilEmpty();
             }
-            catch (Exception) { /*ignore, may fail because of dispose in the middle of a (second) render pass*/ }
+
+            if (ctx is not null)
+            {
+                await ctx.DisposeAsync();
+            }
+        }
+
+        protected async Task RenderExampleAsync<TComponent>()
+            where TComponent : IComponent
+        {
+            ctx.Render<TComponent>();
+            await renderQueueService.WaitUntilEmpty();
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Reduce CPU/memory and make the generated docs tests safe to run in parallel by preventing shared Bunit context disposal races and redundant service registration work.
- Make the docs test generator emit more efficient, deterministic and async-friendly tests to avoid intermittent `BunitRenderer` disposed errors and long-running synchronous renders.

### Description

- Add `Parallelizable(ParallelScope.All)` and `FixtureLifeCycle(LifeCycle.InstancePerTestCase)` to generated test fixtures and switch to per-test `BunitContext` instances to allow safe parallel execution (files: `ExampleDocsTests.cs`, `ApiDocsTests.cs`).
- Cache default service registrations into a static `ServiceDescriptor[] DefaultServices` and apply them per-test instead of repeatedly adding each service inline, reducing allocation and setup overhead (files: `ExampleDocsTests.cs`, `ApiDocsTests.cs`).
- Use a shared `IRenderQueueService` instance per test fixture to await rendering completion via helper methods `WaitForRenderQueueAsync` and `RenderExampleAsync<TComponent>()`, and change teardown to `DisposeAsync()` only after the render queue is drained to avoid `ObjectDisposedException` from concurrent renders (files: `ExampleDocsTests.cs`, `ApiDocsTests.cs`).
- Make the docs generator emit `async Task` example tests that call `RenderExampleAsync<T>()` instead of synchronous `ctx.Render<>()`, and replace inline `WaitUntilEmpty()` calls with `WaitForRenderQueueAsync()` in generated API tests (files: `TestsForExamples.cs`, `TestsForApiPages.cs`, generated outputs updated).
- Optimize API generator lookups by making `TypesWithExamples` a static property and creating a `HashSet<string>` lookup for fast membership checks, and order component types deterministically with `OrderBy(type => type.FullName)` to reduce nondeterminism and generator cost (file: `TestsForApiPages.cs`).

### Testing

- Attempted to run formatting via `dotnet format src/MudBlazor.UnitTests.Docs.Generator/MudBlazor.UnitTests.Docs.Generator.csproj --include src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs --include src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs` but the environment reported `dotnet` not found, so formatting/test automation was not executed.
- No unit test runs were performed in this environment; changes were compiled into generated test files and committed so they will be exercised in CI when `dotnet` is available and the test suite runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c3cae48d88328a363cf9865849390)