### PR TITLE
Refactor docs tests for batching and isolated contexts

### DIFF
--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
@@ -6,6 +6,7 @@ namespace MudBlazor.UnitTests.Docs.Generator;
 
 public partial class TestsForApiPages
 {
+    private readonly record struct ApiTestCaseInfo(string TypeName, string Url, bool RequiresExampleLink);
     /// <summary>
     /// The current production links to API documentation.
     /// </summary>
@@ -173,6 +174,10 @@ public partial class TestsForApiPages
                 currentCode = File.ReadAllText(Paths.ApiPageTestsFilePath);
             }
 
+            var apiTestCases = new List<ApiTestCaseInfo>();
+            CollectPublicTypeTests(apiTestCases);
+            CollectLegacyApiLinkTests(apiTestCases);
+
             var cb = new CodeBuilder();
 
             cb.AddHeader();
@@ -182,6 +187,7 @@ public partial class TestsForApiPages
             cb.AddLine("using Microsoft.Extensions.DependencyInjection;");
             cb.AddLine("using MudBlazor.Docs.Pages.Api;");
             cb.AddLine("using MudBlazor.Docs.Services;");
+            cb.AddLine("using MudBlazor.Services;");
             cb.AddLine("using NUnit.Framework;");
             cb.AddLine();
             cb.AddLine("namespace MudBlazor.UnitTests.Docs.Generated");
@@ -193,8 +199,8 @@ public partial class TestsForApiPages
             cb.AddLine("{");
             cb.IndentLevel++;
 
-            WritePublicTypeTests(cb);
-            WriteLegacyApiLinkTests(cb);
+            WriteApiTestCases(cb, apiTestCases);
+            WriteApiTests(cb);
 
             cb.IndentLevel--;
             cb.AddLine("}");
@@ -218,7 +224,7 @@ public partial class TestsForApiPages
     /// <summary>
     /// Creates tests for all public MudBlazor types.
     /// </summary>
-    public void WritePublicTypeTests(CodeBuilder cb)
+    private void CollectPublicTypeTests(ICollection<ApiTestCaseInfo> apiTestCases)
     {
         var mudBlazorAssembly = typeof(_Imports).Assembly;
         var mudBlazorComponents = mudBlazorAssembly.GetTypes()
@@ -245,50 +251,64 @@ public partial class TestsForApiPages
                 continue;
             }
 
-            cb.AddLine("[Test]");
-            cb.AddLine($"public async Task {type.Name.Replace("`", "")}_API_TestAsync()");
-            cb.AddLine("{");
-            cb.IndentLevel++;
-            // Create Api.razor with a type
-            cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{type.Name}""));");
-            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{type.Name}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
-            // Make sure docs for the type were actually found
-            cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {type.Name} was not found"");");
-            // Should there be a link to the example page?
-            if (TypesWithExamples.Exists(exampleType => exampleType.Name == type.Name))
-            {
-                // Yes.  Check for the example link
-                cb.AddLine(@$"var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href != null && link.Instance.Href.StartsWith(""/component""));");
-                cb.AddLine(@$"exampleLink.Should().NotBeNull();");
-            }
-            cb.IndentLevel--;
-            cb.AddLine("}");
+            apiTestCases.Add(new ApiTestCaseInfo(
+                type.Name,
+                $"components/{type.Name}",
+                TypesWithExamples.Exists(exampleType => exampleType.Name == type.Name)));
         }
     }
 
     /// <summary>
     /// Creates tests for existing API links (for backwards compatibility).
     /// </summary>
-    public void WriteLegacyApiLinkTests(CodeBuilder cb)
+    private void CollectLegacyApiLinkTests(ICollection<ApiTestCaseInfo> apiTestCases)
     {
         foreach (var url in _legacyApiAddresses)
         {
             var component = url.Replace("api/", "");
 
-            cb.AddLine("[Test]");
-            cb.AddLine($"public async Task {component.Replace("/", "_")}_Legacy_API_TestAsync()");
-            cb.AddLine("{");
-            cb.IndentLevel++;
-            // Create Api.razor with a type
-            cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{url}""));");
-            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{component}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
-            // Make sure docs for the type were actually found
-            cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {component} was not found"");");
-            cb.IndentLevel--;
-            cb.AddLine("}");
+            apiTestCases.Add(new ApiTestCaseInfo(
+                component,
+                $"components/{url}",
+                false));
         }
+    }
+
+    private static void WriteApiTestCases(CodeBuilder cb, IEnumerable<ApiTestCaseInfo> apiTestCases)
+    {
+        cb.AddLine("private sealed record ApiTestCase(string TypeName, string Url, bool RequiresExampleLink);");
+        cb.AddLine("private static readonly ApiTestCase[] ApiTestCases =");
+        cb.AddLine("[");
+        cb.IndentLevel++;
+        foreach (var testCase in apiTestCases.OrderBy(testCase => testCase.Url, StringComparer.Ordinal))
+        {
+            cb.AddLine($@"new ApiTestCase(""{testCase.TypeName}"", ""{testCase.Url}"", {testCase.RequiresExampleLink.ToString().ToLowerInvariant()}),");
+        }
+        cb.IndentLevel--;
+        cb.AddLine("];");
+        cb.AddLine();
+    }
+
+    private static void WriteApiTests(CodeBuilder cb)
+    {
+        cb.AddLine("[TestCaseSource(nameof(ApiTestCases))]");
+        cb.AddLine("public async Task ApiPages_Render_Without_Errors(ApiTestCase testCase)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        cb.AddLine("await using var ctx = CreateContext();");
+        cb.AddLine(@"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", $""https://localhost:2112/{testCase.Url}"" ));");
+        cb.AddLine("var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, testCase.TypeName));");
+        cb.AddLine("await ctx.Services.GetRequiredService<IRenderQueueService>().WaitUntilEmpty();");
+        cb.AddLine(@"comp.Markup.Should().NotContain($""Sorry, the type {testCase.TypeName} was not found"");");
+        cb.AddLine("if (testCase.RequiresExampleLink)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        cb.AddLine(@"var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href != null && link.Instance.Href.StartsWith(""/component""));");
+        cb.AddLine("exampleLink.Should().NotBeNull();");
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.IndentLevel--;
+        cb.AddLine("}");
     }
 
     /// <summary>

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
@@ -18,8 +18,11 @@ public class TestsForExamples
             var cb = new CodeBuilder();
 
             cb.AddHeader();
+            cb.AddLine("using System;");
+            cb.AddLine("using Microsoft.Extensions.DependencyInjection;");
             cb.AddLine("using MudBlazor.Docs.Examples;");
             cb.AddLine("using MudBlazor.Docs.Wireframes;");
+            cb.AddLine("using MudBlazor.Services;");
             cb.AddLine("using NUnit.Framework;");
             cb.AddLine();
 
@@ -31,6 +34,7 @@ public class TestsForExamples
             cb.AddLine("public partial class ExampleDocsTests");
             cb.AddLine("{");
             cb.IndentLevel++;
+            var exampleComponents = new List<string>();
 
             foreach (var entry in Directory.EnumerateFiles(Paths.DocsDirPath, "*.razor", SearchOption.AllDirectories)
                 .OrderBy(e => e.Replace("\\", "/"), StringComparer.Ordinal))
@@ -44,14 +48,47 @@ public class TestsForExamples
                 // skip over table/data grid virtualization since it takes too long.
                 if (filename == "TableVirtualizationExample.razor" || filename == "DataGridVirtualizationExample.razor")
                     continue;
-                cb.AddLine("[Test]");
-                cb.AddLine($"public void {componentName}_Test()");
-                cb.AddLine("{");
-                cb.IndentLevel++;
-                cb.AddLine($"ctx.Render<{componentName}>();");
-                cb.IndentLevel--;
-                cb.AddLine("}");
+                exampleComponents.Add(componentName);
             }
+
+            cb.AddLine("private static readonly Type[][] ExampleComponentBatches =");
+            cb.AddLine("[");
+            cb.IndentLevel++;
+            const int batchSize = 12;
+            for (var i = 0; i < exampleComponents.Count; i += batchSize)
+            {
+                cb.AddLine("[");
+                cb.IndentLevel++;
+                foreach (var componentName in exampleComponents.Skip(i).Take(batchSize))
+                {
+                    cb.AddLine($"typeof({componentName}),");
+                }
+                cb.IndentLevel--;
+                cb.AddLine("],");
+            }
+            cb.IndentLevel--;
+            cb.AddLine("];");
+            cb.AddLine();
+            cb.AddLine("[TestCaseSource(nameof(ExampleComponentBatches))]");
+            cb.AddLine("public async Task Examples_Render_Without_Errors(Type[] components)");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+            cb.AddLine("await using var context = CreateContext();");
+            cb.AddLine("foreach (var componentType in components)");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+            cb.AddLine("context.RenderInsideRenderTree(builder =>");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+            cb.AddLine("builder.OpenComponent(0, componentType);");
+            cb.AddLine("builder.CloseComponent();");
+            cb.IndentLevel--;
+            cb.AddLine("});");
+            cb.AddLine("await context.Services.GetRequiredService<IRenderQueueService>().WaitUntilEmpty();");
+            cb.IndentLevel--;
+            cb.AddLine("}");
+            cb.IndentLevel--;
+            cb.AddLine("}");
 
             cb.IndentLevel--;
             cb.AddLine("}");

--- a/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
@@ -13,12 +13,9 @@ namespace MudBlazor.UnitTests.Docs.Generated
     [TestFixture]
     public partial class ApiDocsTests
     {
-        private Bunit.BunitContext ctx;
-
-        [SetUp]
-        public void Setup()
+        protected static BunitContext CreateContext()
         {
-            ctx = new Bunit.BunitContext();
+            var ctx = new BunitContext();
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.Services.AddSingleton(TimeProvider.System);
             ctx.Services.AddSingleton<IDialogService>(new DialogService());
@@ -43,6 +40,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
             ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
             ctx.Services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
             ctx.Services.AddScoped(sp => new HttpClient());
+            return ctx;
         }
 
         // This shows how to test a docs page with incremental rendering.
@@ -50,9 +48,10 @@ namespace MudBlazor.UnitTests.Docs.Generated
         [Test]
         public async Task AlertPage_Test()
         {
+            await using var ctx = CreateContext();
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/alert"));
-            var comp = ctx.Render<MudBlazor.Docs.Pages.Components.Alert.AlertPage>();
-            await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
+            ctx.Render<MudBlazor.Docs.Pages.Components.Alert.AlertPage>();
+            await ctx.Services.GetRequiredService<IRenderQueueService>().WaitUntilEmpty();
         }
 
         /// <summary>
@@ -61,15 +60,13 @@ namespace MudBlazor.UnitTests.Docs.Generated
         [Test]
         public async Task MudAlert_API_Test_Example()
         {
+            await using var ctx = CreateContext();
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/MudAlert"));
             var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, "MudAlert"));
-            await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
+            await ctx.Services.GetRequiredService<IRenderQueueService>().WaitUntilEmpty();
             comp.Markup.Should().NotContain("Sorry, the type").And.NotContain("could not be found");
             var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href.StartsWith("/component"));
             exampleLink.Should().NotBeNull();
         }
-
-        [TearDown]
-        public async Task TearDown() => await ctx.DisposeAsync();
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
@@ -12,12 +12,9 @@ namespace MudBlazor.UnitTests.Docs.Generated
     [TestFixture]
     public partial class ExampleDocsTests
     {
-        private BunitContext ctx;
-
-        [SetUp]
-        public void Setup()
+        protected static BunitContext CreateContext()
         {
-            ctx = new BunitContext();
+            var ctx = new BunitContext();
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.Services.AddSingleton(TimeProvider.System);
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
@@ -44,16 +41,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
             ctx.Services.AddOptions();
             ctx.Services.AddScoped(sp =>
                 new HttpClient(new MockDocsMessageHandler()) { BaseAddress = new Uri("https://localhost/") });
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            try
-            {
-                ctx.Dispose();
-            }
-            catch (Exception) { /*ignore, may fail because of dispose in the middle of a (second) render pass*/ }
+            return ctx;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Generated docs tests were causing high CPU/memory and bUnit renderer disposal races when run in parallel, so the generator and generated tests needed to create isolated contexts and reduce per-test overhead.
- Rendering every example as an individual test increases renderer churn and contention; batching reduces renders and synchronization frequency.

### Description
- Batch example renders: `TestsForExamples` now collects example component types and emits `private static readonly Type[][] ExampleComponentBatches` with a configurable `batchSize` and a single parameterized test `Examples_Render_Without_Errors(Type[] components)` that renders each component in a batch and awaits the render queue after each component.
- Isolated contexts per test: both generators now emit and/or use a `CreateContext()` helper returning a configured `BunitContext`, and each test creates and disposes its own context instead of sharing a single `ctx` instance.
- API tests refactor: `TestsForApiPages` now collects `ApiTestCaseInfo` entries, emits a single `ApiTestCases` array and a parameterized `ApiPages_Render_Without_Errors(ApiTestCase testCase)` test that creates an isolated context, renders the `Api` page and awaits the `IRenderQueueService` to empty before asserting.
- Generated fixtures updated: `ExampleDocsTests.cs` and `ApiDocsTests.cs` now include `CreateContext()` and call `GetRequiredService<IRenderQueueService>().WaitUntilEmpty()`; removed shared `ctx` lifetime that led to renderer disposal errors.

### Testing
- Attempted to run formatting via `dotnet format <proj> --include <files>` but `dotnet` was not available in the environment, so formatting/validation could not be executed (failed).
- No `dotnet build` or `dotnet test` was executed in this environment; recommend running `dotnet build` and targeted tests locally or in CI, for example: `dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MudButton" --no-build -c Release` and full docs tests in `src/MudBlazor.UnitTests.Docs` to verify behavior and parallel runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c4070f7848328be9440aa10b66907)