### PR TITLE
Generate TestCaseSource-based docs tests and add parallelizable test methods

### DIFF
--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
@@ -178,6 +178,8 @@ public partial class TestsForApiPages
             cb.AddHeader();
             cb.AddLine("using Bunit;");
             cb.AddLine("using AwesomeAssertions;");
+            cb.AddLine("using System;");
+            cb.AddLine("using System.Collections.Generic;");
             cb.AddLine("using Microsoft.AspNetCore.Components;");
             cb.AddLine("using Microsoft.Extensions.DependencyInjection;");
             cb.AddLine("using MudBlazor.Docs.Pages.Api;");
@@ -193,8 +195,8 @@ public partial class TestsForApiPages
             cb.AddLine("{");
             cb.IndentLevel++;
 
-            WritePublicTypeTests(cb);
-            WriteLegacyApiLinkTests(cb);
+            WriteApiCases(cb);
+            WriteApiTest(cb);
 
             cb.IndentLevel--;
             cb.AddLine("}");
@@ -216,9 +218,9 @@ public partial class TestsForApiPages
     }
 
     /// <summary>
-    /// Creates tests for all public MudBlazor types.
+    /// Creates test cases for all public MudBlazor types and legacy API routes.
     /// </summary>
-    public void WritePublicTypeTests(CodeBuilder cb)
+    public void WriteApiCases(CodeBuilder cb)
     {
         var mudBlazorAssembly = typeof(_Imports).Assembly;
         var mudBlazorComponents = mudBlazorAssembly.GetTypes()
@@ -237,6 +239,10 @@ public partial class TestsForApiPages
                 // ... which aren't clone strategies
                 && !type.Name.Contains("SystemTextJson"))
             .ToList();
+        cb.AddLine("public static IEnumerable<TestCaseData> ApiCases()");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+
         foreach (var type in mudBlazorComponents)
         {
             // Skip MudBlazor.Color and MudBlazor.Input types
@@ -245,50 +251,53 @@ public partial class TestsForApiPages
                 continue;
             }
 
-            cb.AddLine("[Test]");
-            cb.AddLine($"public async Task {type.Name.Replace("`", "")}_API_TestAsync()");
-            cb.AddLine("{");
+            var hasExample = TypesWithExamples.Exists(exampleType => exampleType.Name == type.Name);
+            cb.AddLine($"yield return new TestCaseData(\"{type.Name}\", \"{type.Name}\", {hasExample.ToString().ToLowerInvariant()})");
             cb.IndentLevel++;
-            // Create Api.razor with a type
-            cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{type.Name}""));");
-            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{type.Name}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
-            // Make sure docs for the type were actually found
-            cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {type.Name} was not found"");");
-            // Should there be a link to the example page?
-            if (TypesWithExamples.Exists(exampleType => exampleType.Name == type.Name))
-            {
-                // Yes.  Check for the example link
-                cb.AddLine(@$"var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href != null && link.Instance.Href.StartsWith(""/component""));");
-                cb.AddLine(@$"exampleLink.Should().NotBeNull();");
-            }
+            cb.AddLine($".SetName(\"{type.Name.Replace("`", "")}_API\");");
             cb.IndentLevel--;
-            cb.AddLine("}");
         }
-    }
 
-    /// <summary>
-    /// Creates tests for existing API links (for backwards compatibility).
-    /// </summary>
-    public void WriteLegacyApiLinkTests(CodeBuilder cb)
-    {
         foreach (var url in _legacyApiAddresses)
         {
             var component = url.Replace("api/", "");
-
-            cb.AddLine("[Test]");
-            cb.AddLine($"public async Task {component.Replace("/", "_")}_Legacy_API_TestAsync()");
-            cb.AddLine("{");
+            cb.AddLine($"yield return new TestCaseData(\"{component}\", \"{url}\", false)");
             cb.IndentLevel++;
-            // Create Api.razor with a type
-            cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{url}""));");
-            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{component}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
-            // Make sure docs for the type were actually found
-            cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {component} was not found"");");
+            cb.AddLine($".SetName(\"{component.Replace("/", "_")}_Legacy_API\");");
             cb.IndentLevel--;
-            cb.AddLine("}");
         }
+
+        cb.IndentLevel--;
+        cb.AddLine("}");
+    }
+
+    private static void WriteApiTest(CodeBuilder cb)
+    {
+        cb.AddLine();
+        cb.AddLine("[TestCaseSource(nameof(ApiCases))]");
+        cb.AddLine("[Parallelizable(ParallelScope.All)]");
+        cb.AddLine("public async Task ApiPage_Renders(string typeName, string url, bool expectExampleLink)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        cb.AddLine("ctx.Services.AddSingleton<NavigationManager>(");
+        cb.IndentLevel++;
+        cb.AddLine("new MockNavigationManager(\"https://localhost:2112/\", $\"https://localhost:2112/components/{url}\"));");
+        cb.IndentLevel--;
+        cb.AddLine("var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, typeName));");
+        cb.AddLine("await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
+        cb.AddLine("comp.Markup.Should().NotContain($\"Sorry, the type {typeName} was not found\");");
+        cb.AddLine("if (expectExampleLink)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        cb.AddLine("var exampleLink = comp.FindComponents<MudLink>()");
+        cb.IndentLevel++;
+        cb.AddLine(".FirstOrDefault(link => link.Instance.Href != null && link.Instance.Href.StartsWith(\"/component\"));");
+        cb.IndentLevel--;
+        cb.AddLine("exampleLink.Should().NotBeNull();");
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.IndentLevel--;
+        cb.AddLine("}");
     }
 
     /// <summary>

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
@@ -18,6 +18,8 @@ public class TestsForExamples
             var cb = new CodeBuilder();
 
             cb.AddHeader();
+            cb.AddLine("using System;");
+            cb.AddLine("using System.Collections.Generic;");
             cb.AddLine("using MudBlazor.Docs.Examples;");
             cb.AddLine("using MudBlazor.Docs.Wireframes;");
             cb.AddLine("using NUnit.Framework;");
@@ -32,6 +34,25 @@ public class TestsForExamples
             cb.AddLine("{");
             cb.IndentLevel++;
 
+            cb.AddLine("private const string RunAllExamplesEnvironmentVariable = \"MUDBLAZOR_DOCS_RUN_ALL_EXAMPLES\";");
+            cb.AddLine("private static readonly HashSet<string> HeavyExamples = new(StringComparer.Ordinal)");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+            cb.AddLine("\"TableVirtualizationExample\",");
+            cb.AddLine("\"DataGridVirtualizationExample\"");
+            cb.IndentLevel--;
+            cb.AddLine("};");
+            cb.AddLine();
+            cb.AddLine("private static bool RunAllExamples =>");
+            cb.IndentLevel++;
+            cb.AddLine("string.Equals(Environment.GetEnvironmentVariable(RunAllExamplesEnvironmentVariable), \"1\", StringComparison.OrdinalIgnoreCase)");
+            cb.AddLine("|| string.Equals(Environment.GetEnvironmentVariable(RunAllExamplesEnvironmentVariable), \"true\", StringComparison.OrdinalIgnoreCase);");
+            cb.IndentLevel--;
+            cb.AddLine();
+            cb.AddLine("public static IEnumerable<TestCaseData> ExampleCases()");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+
             foreach (var entry in Directory.EnumerateFiles(Paths.DocsDirPath, "*.razor", SearchOption.AllDirectories)
                 .OrderBy(e => e.Replace("\\", "/"), StringComparer.Ordinal))
             {
@@ -41,17 +62,25 @@ public class TestsForExamples
                 var componentName = Path.GetFileNameWithoutExtension(filename);
                 if (!filename.Contains(Paths.ExampleDiscriminator))
                     continue;
-                // skip over table/data grid virtualization since it takes too long.
                 if (filename == "TableVirtualizationExample.razor" || filename == "DataGridVirtualizationExample.razor")
+                {
+                    cb.AddLine($"if (RunAllExamples) yield return new TestCaseData(typeof({componentName})).SetName(\"{componentName}_Test\");");
                     continue;
-                cb.AddLine("[Test]");
-                cb.AddLine($"public void {componentName}_Test()");
-                cb.AddLine("{");
-                cb.IndentLevel++;
-                cb.AddLine($"ctx.Render<{componentName}>();");
-                cb.IndentLevel--;
-                cb.AddLine("}");
+                }
+                cb.AddLine($"yield return new TestCaseData(typeof({componentName})).SetName(\"{componentName}_Test\");");
             }
+
+            cb.IndentLevel--;
+            cb.AddLine("}");
+            cb.AddLine();
+            cb.AddLine("[TestCaseSource(nameof(ExampleCases))]");
+            cb.AddLine("[Parallelizable(ParallelScope.All)]");
+            cb.AddLine("public void Example_Renders(Type componentType)");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+            cb.AddLine("ctx.RenderComponent(componentType);");
+            cb.IndentLevel--;
+            cb.AddLine("}");
 
             cb.IndentLevel--;
             cb.AddLine("}");


### PR DESCRIPTION
### Motivation

- Reduce per-test overhead by emitting TestCaseSource-driven tests instead of one test method per example/type to make test execution faster and more predictable when parallelized.
- Provide an opt-in mechanism to skip known-heavy examples by default and allow running the full set via an environment variable.
- Centralize API and example test generation to a single shared test method so NUnit can run cases in parallel reliably.

### Description

- Refactored `TestsForExamples.cs` to emit `public static IEnumerable<TestCaseData> ExampleCases()` and a single generated test `Example_Renders(Type componentType)` annotated with `[TestCaseSource(nameof(ExampleCases))]` and `[Parallelizable(ParallelScope.All)]`, and added an opt-in environment variable `MUDBLAZOR_DOCS_RUN_ALL_EXAMPLES` with a `HeavyExamples` set to skip expensive examples by default. 
- Refactored `TestsForApiPages.cs` to emit `public static IEnumerable<TestCaseData> ApiCases()` that yields `(typeName, url, expectExampleLink)` entries for both public types and legacy URLs and added a shared generated test `ApiPage_Renders(string typeName, string url, bool expectExampleLink)` annotated with `[TestCaseSource(nameof(ApiCases))]` and `[Parallelizable(ParallelScope.All)]` that performs the previous per-type assertions.
- Added necessary `using` directives (`System`, `System.Collections.Generic`) to generated files and updated the codegen flow to produce named `TestCaseData` entries using `.SetName(...)` for clearer test names.

### Testing

- Attempted to run `dotnet format` for the generator project to format the changed files but the environment does not have `dotnet` available, so formatting was not executed (failure). 
- No automated unit tests or builds were executed in this environment after the change due to missing .NET tooling, so generated tests have not been validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c46e51c748328a457d1718611a18b)