### PR TITLE
Use TestCaseSource for docs test generators and enable parallel execution

### DIFF
--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
@@ -183,6 +183,7 @@ public partial class TestsForApiPages
             cb.AddLine("using MudBlazor.Docs.Pages.Api;");
             cb.AddLine("using MudBlazor.Docs.Services;");
             cb.AddLine("using NUnit.Framework;");
+            cb.AddLine("using System.Collections.Generic;");
             cb.AddLine();
             cb.AddLine("namespace MudBlazor.UnitTests.Docs.Generated");
             cb.AddLine("{");
@@ -237,6 +238,10 @@ public partial class TestsForApiPages
                 // ... which aren't clone strategies
                 && !type.Name.Contains("SystemTextJson"))
             .ToList();
+        cb.AddLine("private static IEnumerable<TestCaseData> ApiCases()");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+
         foreach (var type in mudBlazorComponents)
         {
             // Skip MudBlazor.Color and MudBlazor.Input types
@@ -245,26 +250,35 @@ public partial class TestsForApiPages
                 continue;
             }
 
-            cb.AddLine("[Test]");
-            cb.AddLine($"public async Task {type.Name.Replace("`", "")}_API_TestAsync()");
-            cb.AddLine("{");
-            cb.IndentLevel++;
-            // Create Api.razor with a type
-            cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{type.Name}""));");
-            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{type.Name}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
-            // Make sure docs for the type were actually found
-            cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {type.Name} was not found"");");
-            // Should there be a link to the example page?
-            if (TypesWithExamples.Exists(exampleType => exampleType.Name == type.Name))
-            {
-                // Yes.  Check for the example link
-                cb.AddLine(@$"var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href != null && link.Instance.Href.StartsWith(""/component""));");
-                cb.AddLine(@$"exampleLink.Should().NotBeNull();");
-            }
-            cb.IndentLevel--;
-            cb.AddLine("}");
+            var testName = type.Name.Replace("`", "");
+            var hasExample = TypesWithExamples.Exists(exampleType => exampleType.Name == type.Name);
+            cb.AddLine($"yield return new TestCaseData(\"{type.Name}\", {hasExample.ToString().ToLowerInvariant()}).SetName(\"{testName}_API_Test\");");
         }
+
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.AddLine();
+        cb.AddLine("[TestCaseSource(nameof(ApiCases))]");
+        cb.AddLine("[Parallelizable(ParallelScope.All)]");
+        cb.AddLine("public async Task ApiPage_Renders(string typeName, bool hasExample)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        // Create Api.razor with a type
+        cb.AddLine("ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(\"https://localhost:2112/\", $\"https://localhost:2112/components/{typeName}\"));");
+        cb.AddLine(@"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, typeName));");
+        cb.AddLine(@"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
+        // Make sure docs for the type were actually found
+        cb.AddLine(@"comp.Markup.Should().NotContain($""Sorry, the type {typeName} was not found"");");
+        cb.AddLine("if (hasExample)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        // Yes.  Check for the example link
+        cb.AddLine(@"var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href != null && link.Instance.Href.StartsWith(""/component""));");
+        cb.AddLine(@"exampleLink.Should().NotBeNull();");
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.IndentLevel--;
+        cb.AddLine("}");
     }
 
     /// <summary>
@@ -272,23 +286,32 @@ public partial class TestsForApiPages
     /// </summary>
     public void WriteLegacyApiLinkTests(CodeBuilder cb)
     {
+        cb.AddLine("private static IEnumerable<TestCaseData> LegacyApiCases()");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+
         foreach (var url in _legacyApiAddresses)
         {
             var component = url.Replace("api/", "");
-
-            cb.AddLine("[Test]");
-            cb.AddLine($"public async Task {component.Replace("/", "_")}_Legacy_API_TestAsync()");
-            cb.AddLine("{");
-            cb.IndentLevel++;
-            // Create Api.razor with a type
-            cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{url}""));");
-            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{component}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
-            // Make sure docs for the type were actually found
-            cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {component} was not found"");");
-            cb.IndentLevel--;
-            cb.AddLine("}");
+            cb.AddLine($"yield return new TestCaseData(\"{component}\", \"{url}\").SetName(\"{component.Replace("/", "_")}_Legacy_API_Test\");");
         }
+
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.AddLine();
+        cb.AddLine("[TestCaseSource(nameof(LegacyApiCases))]");
+        cb.AddLine("[Parallelizable(ParallelScope.All)]");
+        cb.AddLine("public async Task LegacyApiPage_Renders(string component, string url)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        // Create Api.razor with a type
+        cb.AddLine("ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(\"https://localhost:2112/\", $\"https://localhost:2112/components/{url}\"));");
+        cb.AddLine(@"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, component));");
+        cb.AddLine(@"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
+        // Make sure docs for the type were actually found
+        cb.AddLine(@"comp.Markup.Should().NotContain($""Sorry, the type {component} was not found"");");
+        cb.IndentLevel--;
+        cb.AddLine("}");
     }
 
     /// <summary>

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
@@ -21,6 +21,8 @@ public class TestsForExamples
             cb.AddLine("using MudBlazor.Docs.Examples;");
             cb.AddLine("using MudBlazor.Docs.Wireframes;");
             cb.AddLine("using NUnit.Framework;");
+            cb.AddLine("using System;");
+            cb.AddLine("using System.Collections.Generic;");
             cb.AddLine();
 
             cb.AddLine("namespace MudBlazor.UnitTests.Docs.Generated");
@@ -29,6 +31,10 @@ public class TestsForExamples
             cb.AddLine("// These tests just check if all the examples from the doc page render without errors");
             cb.AddLine("[System.CodeDom.Compiler.GeneratedCodeAttribute(\"MudBlazor.Docs.Compiler\", \"0.0.0.0\")]");
             cb.AddLine("public partial class ExampleDocsTests");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+
+            cb.AddLine("private static IEnumerable<TestCaseData> ExampleCases()");
             cb.AddLine("{");
             cb.IndentLevel++;
 
@@ -44,14 +50,21 @@ public class TestsForExamples
                 // skip over table/data grid virtualization since it takes too long.
                 if (filename == "TableVirtualizationExample.razor" || filename == "DataGridVirtualizationExample.razor")
                     continue;
-                cb.AddLine("[Test]");
-                cb.AddLine($"public void {componentName}_Test()");
-                cb.AddLine("{");
-                cb.IndentLevel++;
-                cb.AddLine($"ctx.Render<{componentName}>();");
-                cb.IndentLevel--;
-                cb.AddLine("}");
+
+                cb.AddLine($"yield return new TestCaseData(typeof({componentName})).SetName(\"{componentName}_Test\");");
             }
+
+            cb.IndentLevel--;
+            cb.AddLine("}");
+            cb.AddLine();
+            cb.AddLine("[TestCaseSource(nameof(ExampleCases))]");
+            cb.AddLine("[Parallelizable(ParallelScope.All)]");
+            cb.AddLine("public void Example_Renders(Type componentType)");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+            cb.AddLine("ctx.RenderComponent(componentType);");
+            cb.IndentLevel--;
+            cb.AddLine("}");
 
             cb.IndentLevel--;
             cb.AddLine("}");


### PR DESCRIPTION
### Motivation
- Reduce per-test overhead and make parallel execution predictable by switching from one test method per example/type to `TestCaseSource`-driven tests.
- Consolidate generated tests into a small number of test methods that iterate over enumerables to improve generator output and runtime performance.

### Description
- Update `TestsForExamples.cs` to emit a `private static IEnumerable<TestCaseData> ExampleCases()` that yields `TestCaseData` for each example and a single `[TestCaseSource(nameof(ExampleCases))]` test `Example_Renders(Type componentType)` which calls `ctx.RenderComponent(componentType)`.
- Update `TestsForApiPages.cs` to emit `ApiCases()` and `LegacyApiCases()` enumerables and single `[TestCaseSource]` tests `ApiPage_Renders(string typeName, bool hasExample)` and `LegacyApiPage_Renders(string component, string url)` that perform the same assertions previously generated per-type.
- Add `using System.Collections.Generic;` and `using System;` where needed in generated output and set names for test cases using `.SetName(...)`.
- Mark the generated test methods with `[Parallelizable(ParallelScope.All)]` to allow predictable parallel runs.

### Testing
- Formatting was attempted with `dotnet format src/MudBlazor.UnitTests.Docs.Generator/MudBlazor.UnitTests.Docs.Generator.csproj --include src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs`, but the `dotnet` tool was not available in the environment and the command failed.
- No automated unit tests or builds were executed in this environment because the .NET SDK is unavailable, so generated output was validated by inspection only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c4aa438008328bd768bed55bae38e)