### PR TITLE
Docs: Add Ctrl+K search shortcut and Esc-close behavior

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -1,4 +1,9 @@
-﻿<div class="d-flex align-center flex-grow-1 d-md-none">
+﻿@using MudBlazor.Utilities
+
+<MudHotkey Key="JsKey.KeyK" KeyModifiers="CtrlLeftKeyModifiers" OnHotkeyPressed="HandleSearchHotkeyAsync" />
+<MudHotkey Key="JsKey.KeyK" KeyModifiers="CtrlRightKeyModifiers" OnHotkeyPressed="HandleSearchHotkeyAsync" />
+
+<div class="d-flex align-center flex-grow-1 d-md-none">
     <MudIconButton OnClick="DrawerToggleCallback" Icon="@Icons.Material.Rounded.Notes" Color="Color.Inherit" Edge="Edge.Start" aria-label="Toggle drawer" />
     <MudSpacer />
     <NavLink ActiveClass="d-flex align-center" href="/">
@@ -6,8 +11,8 @@
         <MudText Color="Color.Primary" Typo="Typo.h5" Class="docs-brand-text">MudBlazor</MudText>
     </NavLink>
     <MudSpacer />
-    <MudTooltip Text="Search">
-        <MudIconButton Icon="@Icons.Material.Rounded.Search" Color="Color.Inherit" Edge="Edge.End" OnClick="@(() => OpenSearchDialog())" aria-label="Open search dialog" />
+    <MudTooltip Text="Search (Ctrl+K)">
+        <MudIconButton Icon="@Icons.Material.Rounded.Search" Color="Color.Inherit" Edge="Edge.End" OnClick="@(() => OpenSearchDialog())" aria-label="Open search dialog" aria-keyshortcuts="Control+K" />
     </MudTooltip>
 </div>
 <div class="d-none d-md-flex align-center flex-grow-1">
@@ -69,10 +74,11 @@
     <MudSpacer />
     @if (DisplaySearchBar)
     {
-        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar mx-4"
-                         AutoFocus="false" Placeholder="Search" Variant="Variant.Outlined" MaxHeight="480"
+        <MudAutocomplete @ref="_searchBarAutocomplete" T="ApiLinkServiceEntry" Class="docs-search-bar mx-4"
+                         AutoFocus="false" Placeholder="Search (Ctrl+K)" Variant="Variant.Outlined" MaxHeight="480"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
-                         ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" AdornmentAriaLabel="Search adornment">
+                         ValueChanged="OnSearchResult" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" AdornmentAriaLabel="Search adornment"
+                         aria-keyshortcuts="Control+K">
             <ItemTemplate Context="result">
                 <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
             </ItemTemplate>
@@ -81,8 +87,8 @@
     }
     else
     {
-        <MudTooltip Text="Search">
-            <MudIconButton Icon="@Icons.Material.Rounded.Search" Color="Color.Inherit" OnClick="@(() => OpenSearchDialog())" aria-label="Open search dialog" />
+        <MudTooltip Text="Search (Ctrl+K)">
+            <MudIconButton Icon="@Icons.Material.Rounded.Search" Color="Color.Inherit" OnClick="@(() => OpenSearchDialog())" aria-label="Open search dialog" aria-keyshortcuts="Control+K" />
         </MudTooltip>
     }
     <AppbarButtons />
@@ -93,8 +99,8 @@
 
 <MudDialog @bind-Visible="IsSearchDialogOpen" Options="_dialogOptions" Class="docs-gray-bg" ContentClass="docs-mobile-dialog-search d-flex flex-column" DefaultFocus="DefaultFocus.FirstChild">
     <DialogContent>
-        <MudAutocomplete @ref="_searchAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" PopoverFixed="@true"
-                         AutoFocus="true" Placeholder="Search" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+        <MudAutocomplete @ref="_searchDialogAutocomplete" T="ApiLinkServiceEntry" PopoverClass="docs-mobile-dialog-search-popover" PopoverFixed="@true"
+                         AutoFocus="true" Placeholder="Search (Esc to close)" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
                          SearchFunc="async (text, token) => await Search(text, token)" DebounceInterval="0"
                          ValueChanged="OnSearchResult" OpenChanged="o => _searchDialogAutocompleteOpen = o" ReturnedItemsCountChanged="c => _searchDialogReturnedItemsCount = c">
             <ItemTemplate Context="result">

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Models;
 using MudBlazor.Docs.Services;
+using MudBlazor.Utilities;
 
 namespace MudBlazor.Docs.Shared;
 
@@ -15,8 +16,11 @@ public partial class Appbar
     private bool _searchDialogOpen;
     private bool _searchDialogAutocompleteOpen;
     private int _searchDialogReturnedItemsCount;
-    private MudAutocomplete<ApiLinkServiceEntry> _searchAutocomplete = null!;
-    private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true };
+    private MudAutocomplete<ApiLinkServiceEntry>? _searchBarAutocomplete;
+    private MudAutocomplete<ApiLinkServiceEntry>? _searchDialogAutocomplete;
+    private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true, CloseOnEscapeKey = true };
+    private static readonly JsKeyModifier[] CtrlLeftKeyModifiers = [JsKeyModifier.ControlLeft];
+    private static readonly JsKeyModifier[] CtrlRightKeyModifiers = [JsKeyModifier.ControlRight];
 
     public bool IsSearchDialogOpen
     {
@@ -53,7 +57,15 @@ public partial class Appbar
 
         NavigationManager.NavigateTo(entry.Link);
         await Task.Delay(1000);
-        await _searchAutocomplete.ClearAsync();
+        if (_searchBarAutocomplete is not null)
+        {
+            await _searchBarAutocomplete.ClearAsync();
+        }
+
+        if (_searchDialogAutocomplete is not null)
+        {
+            await _searchDialogAutocomplete.ClearAsync();
+        }
     }
 
     private string GetActiveClass(DocsBasePage page)
@@ -73,4 +85,15 @@ public partial class Appbar
     }
 
     private void OpenSearchDialog() => IsSearchDialogOpen = true;
+
+    private async Task HandleSearchHotkeyAsync()
+    {
+        if (DisplaySearchBar && _searchBarAutocomplete is not null)
+        {
+            await _searchBarAutocomplete.FocusAsync();
+            return;
+        }
+
+        OpenSearchDialog();
+    }
 }


### PR DESCRIPTION
### Motivation

- Improve keyboard accessibility so users can open the docs search with `Ctrl+K` and see hints about the shortcut. 
- Ensure the mobile/landing search dialog closes fully with `Escape` and show `Esc` guidance in the placeholder. 
- Keep changes purely C# using existing components and key-interceptor/hotkey infrastructure.

### Description

- Registered two `MudHotkey` entries for `JsKey.KeyK` (left/right control) and added `HandleSearchHotkeyAsync` to focus the inline search or open the search dialog. 
- Added `CtrlLeftKeyModifiers` / `CtrlRightKeyModifiers`, wired the autocomplete refs (`_searchBarAutocomplete`, `_searchDialogAutocomplete`) and updated `OnSearchResult` to clear both inputs after navigation. 
- Added UI hints: changed tooltips/placeholders to include `(Ctrl+K)` or `(Esc to close)` and added `aria-keyshortcuts="Control+K"` attributes on relevant search controls. 
- Enabled dialog `CloseOnEscapeKey` via `DialogOptions` to allow full dialog close with `Escape` without adding any JS.

### Testing

- Ran `dotnet format` to format the modified files but it failed because `dotnet` is not available in the current environment. 
- No project build or unit tests were executed in this environment due to missing `dotnet`; changes are limited to `src/MudBlazor.Docs/Shared/Appbar.razor` and `src/MudBlazor.Docs/Shared/Appbar.razor.cs` and should be validated locally or in CI with `dotnet build` and the docs site run. 
- Manual code inspection was performed to ensure no new JS was introduced and accessibility attributes (`aria-keyshortcuts`) and `DialogOptions.CloseOnEscapeKey` were applied as requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976503155f4832880bf04a093e540f9)