### PR TITLE
Replace TriggerEvent usage with bUnit async helpers and remove unnecessary InvokeAsync wrappers in tests

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
@@ -905,7 +905,7 @@ public class RadarChartTests : BunitTest
         seriesPath.Should().NotBeNull();
 
         // Simulate mouseover to trigger tooltip
-        await seriesPath.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await seriesPath.MouseOverAsync(new MouseEventArgs());
 
         var tooltip = comp.Find("g.svg-tooltip");
         tooltip.Should().NotBeNull();
@@ -940,7 +940,7 @@ public class RadarChartTests : BunitTest
 
         var seriesPath = comp.Find("path.mud-chart-serie");
         seriesPath.Should().NotBeNull();
-        await seriesPath.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await seriesPath.MouseOverAsync(new MouseEventArgs());
 
         var tooltipContent = comp.Find("div.custom-tooltip-test");
         tooltipContent.Should().NotBeNull();
@@ -969,7 +969,7 @@ public class RadarChartTests : BunitTest
         dataMarkers.Count.Should().Be(seriesData.Length);
 
         var firstMarker = dataMarkers.First();
-        await firstMarker.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await firstMarker.MouseOverAsync(new MouseEventArgs());
 
         var tooltip = comp.Find("g.svg-tooltip");
         tooltip.Should().NotBeNull();
@@ -992,7 +992,7 @@ public class RadarChartTests : BunitTest
         // Re-find marker and re-trigger hover after re-render
         dataMarkers = comp.FindAll("circle.mud-chart-series-point");
         firstMarker = dataMarkers.First();
-        await firstMarker.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await firstMarker.MouseOverAsync(new MouseEventArgs());
 
         var customTooltipContent = comp.Find("div.custom-tooltip-test");
         customTooltipContent.Should().NotBeNull();
@@ -1001,7 +1001,7 @@ public class RadarChartTests : BunitTest
         // Hover on the second marker
         dataMarkers = comp.FindAll("circle.mud-chart-series-point");
         var secondMarker = dataMarkers[1];
-        await secondMarker.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await secondMarker.MouseOverAsync(new MouseEventArgs());
         customTooltipContent = comp.Find("div.custom-tooltip-test"); // Re-find, content should update
         customTooltipContent.TextContent.Should().Be($"{seriesName}, Value: {seriesData[1]}");
     }
@@ -1027,12 +1027,12 @@ public class RadarChartTests : BunitTest
         seriesPath.Should().NotBeNull();
 
         // Mouse over to show tooltip
-        await seriesPath.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await seriesPath.MouseOverAsync(new MouseEventArgs());
         var tooltip = comp.Find("g.svg-tooltip");
         tooltip.Should().NotBeNull("Tooltip should be visible on mouseover.");
 
         // Mouse out to hide tooltip
-        await seriesPath.TriggerEventAsync("onmouseout", new MouseEventArgs());
+        await seriesPath.MouseOutAsync(new MouseEventArgs());
         comp.FindAll("g.svg-tooltip").Count.Should().Be(0, "Tooltip content should be removed or hidden on mouseout.");
     }
 

--- a/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
@@ -607,14 +607,14 @@ public class RoseChartTests : BunitTest
         petals.Count.Should().Be(2);
         var firstPetal = petals.First();
 
-        await firstPetal.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await firstPetal.MouseOverAsync(new MouseEventArgs());
 
         var tooltip = comp.Find("g.svg-tooltip");
         tooltip.Should().NotBeNull("Tooltip should be present in the DOM after mouseover");
 
         tooltip.QuerySelector("text tspan").InnerHtml.Should().Be("A - 10");
 
-        await firstPetal.TriggerEventAsync("onmouseout", new MouseEventArgs());
+        await firstPetal.MouseOutAsync(new MouseEventArgs());
         comp.FindAll("g.svg-tooltip").Should().BeEmpty();
     }
 
@@ -637,7 +637,7 @@ public class RoseChartTests : BunitTest
         petals.Count.Should().Be(2);
         var firstPetal = petals.First();
 
-        await firstPetal.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await firstPetal.MouseOverAsync(new MouseEventArgs());
 
         var tooltip = comp.FindAll("g.svg-tooltip");
         tooltip.Should().BeEmpty();
@@ -670,7 +670,7 @@ public class RoseChartTests : BunitTest
         var petals = comp.FindAll("path.mud-chart-serie");
         var firstPetal = petals.First();
 
-        await firstPetal.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await firstPetal.MouseOverAsync(new MouseEventArgs());
 
         var customContent = comp.Find("div.custom-tooltip-content");
         customContent.Should().NotBeNull();
@@ -697,7 +697,7 @@ public class RoseChartTests : BunitTest
 
         var firstPetal = comp.Find("path.mud-chart-serie");
 
-        await firstPetal.TriggerEventAsync("onmouseover", new MouseEventArgs());
+        await firstPetal.MouseOverAsync(new MouseEventArgs());
 
         var tooltipDiv = comp.Find("g.svg-tooltip text");
         tooltipDiv.Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
@@ -563,7 +563,7 @@ namespace MudBlazor.UnitTests.Charts
             // The ChartTooltip component should be present
             var bar = comp.Find("path.mud-chart-bar");
 
-            await bar.TriggerEventAsync("onmouseover", new MouseEventArgs());
+            await bar.MouseOverAsync(new MouseEventArgs());
 
             var tooltip = comp.Find("g.svg-tooltip");
             tooltip.Should().NotBeNull();
@@ -693,7 +693,7 @@ namespace MudBlazor.UnitTests.Charts
 
             var bar = comp.Find("path.mud-chart-bar");
 
-            await bar.TriggerEventAsync("onmouseover", new MouseEventArgs());
+            await bar.MouseOverAsync(new MouseEventArgs());
 
             var customContent = comp.Find("div.custom-tooltip-content");
             customContent.Should().NotBeNull();
@@ -722,7 +722,7 @@ namespace MudBlazor.UnitTests.Charts
 
             var bar = comp.Find("path.mud-chart-bar");
 
-            await bar.TriggerEventAsync("onmouseover", new MouseEventArgs());
+            await bar.MouseOverAsync(new MouseEventArgs());
 
             _tooltipPositionFuncCalled.Should().BeTrue();
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3332,14 +3332,11 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
-            await comp.InvokeAsync(async () =>
-            {
-                var buttons = dataGrid.FindAll("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon");
-                await buttons[10].ClickAsync();
+            var buttons = dataGrid.FindAll("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon");
+            await buttons[10].ClickAsync();
 
-                dataGrid.FindAll("td")
+            dataGrid.FindAll("td")
                 .SingleOrDefault(x => x.TextContent.Trim().StartsWith("uid = Alicia|54|Info|")).Should().BeNull();
-            });
         }
 
         [Test]
@@ -3484,33 +3481,27 @@ namespace MudBlazor.UnitTests.Components
             var popoverProvider = comp.FindComponent<MudPopoverProvider>();
 
             dataGrid.FindAll(".mud-table-head th").Count.Should().Be(6);
-            await comp.InvokeAsync(async () =>
-            {
-                var columnHamburger = dataGrid.FindAll("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon.mud-icon-button-size-small");
-                await columnHamburger[2].ClickAsync();
-                var listItems = popoverProvider.FindComponents<MudMenuItem>();
-                listItems.Count.Should().Be(2);
-                var clickablePopover = listItems[1].Find(".mud-menu-item");
-                await clickablePopover.ClickAsync();
-                ((IMudStateHasChanged)dataGrid.Instance).StateHasChanged();
-            });
+            var columnHamburger = dataGrid.FindAll("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon.mud-icon-button-size-small");
+            await columnHamburger[2].ClickAsync();
+            var listItems = popoverProvider.FindComponents<MudMenuItem>();
+            listItems.Count.Should().Be(2);
+            var clickablePopover = listItems[1].Find(".mud-menu-item");
+            await clickablePopover.ClickAsync();
+            await comp.InvokeAsync(() => ((IMudStateHasChanged)dataGrid.Instance).StateHasChanged());
 
             await dataGrid.WaitForAssertionAsync(() =>
             {
                 dataGrid.FindAll(".mud-table-head th").Count.Should().Be(5);
             });
 
-            await comp.InvokeAsync(async () =>
-            {
-                var columnsButton = dataGrid.Find("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon.mud-icon-button-size-small");
-                await columnsButton.ClickAsync();
-                var popover = dataGrid.FindComponent<MudPopover>();
-                popover.Instance.Open.Should().BeTrue("Should be open once clicked");
-                var listItems = popoverProvider.FindComponents<MudMenuItem>();
-                listItems.Count.Should().Be(1);
-                var clickablePopover = listItems[0].Find(".mud-menu-item");
-                await clickablePopover.ClickAsync();
-            });
+            var columnsButton = dataGrid.Find("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon.mud-icon-button-size-small");
+            await columnsButton.ClickAsync();
+            var popover = dataGrid.FindComponent<MudPopover>();
+            popover.Instance.Open.Should().BeTrue("Should be open once clicked");
+            listItems = popoverProvider.FindComponents<MudMenuItem>();
+            listItems.Count.Should().Be(1);
+            clickablePopover = listItems[0].Find(".mud-menu-item");
+            await clickablePopover.ClickAsync();
 
             // Wait for switches, icons and buttons to appear
             await comp.WaitForAssertionAsync(async () =>

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1669,7 +1669,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DatePickerWithFixYearAndFixMonth()
         {
             var comp = Context.Render<FixYearFixMonthTest>();
-            await comp.Find("input").TriggerEventAsync("onclick", new MouseEventArgs());
+            await comp.Find("input").ClickAsync(new MouseEventArgs());
             await Task.Delay(500);
             comp.Find(".mud-button-year").GetInnerText().Should().Be("2022");
             comp.Find(".mud-picker-calendar-header-transition").GetInnerText().Should().Be("October 2022");

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -926,14 +926,14 @@ namespace MudBlazor.UnitTests.Components
             var openBtn = picker[0].FindComponents<MudIconButton>();
             openBtn.Count.Should().Be(1);
             var openBtnElement = openBtn[0].Find("button");
-            await openBtnElement.TriggerEventAsync("onclick", new MouseEventArgs());
+            await openBtnElement.ClickAsync(new MouseEventArgs());
             await Task.Delay(500);
             IElement DayButton(string dayNumber) =>
                 comp.FindAll("button")
                     .SingleOrDefault(x => x.GetStyle().GetPropertyValue("--day-id") == dayNumber);
-            await DayButton("5").TriggerEventAsync("onclick", new MouseEventArgs());
+            await DayButton("5").ClickAsync(new MouseEventArgs());
             await Task.Delay(200);
-            await DayButton("7").TriggerEventAsync("onclick", new MouseEventArgs());
+            await DayButton("7").ClickAsync(new MouseEventArgs());
             await Task.Delay(200);
 
             IReadOnlyList<IRenderedComponent<MudIconButton>> IconButtons(int index) =>

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -108,7 +108,7 @@ namespace MudBlazor.UnitTests.Components
                 var parent = (IHtmlElement)item.Parent;
                 parent.Children.Should().HaveCount(2, because: "the button and the empty popover hint since it's not active");
 
-                await item.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+                await item.ParentElement.PointerEnterAsync(new PointerEventArgs());
 
                 var popoverId = parent.Children[1].Id.Substring(8);
 
@@ -117,7 +117,7 @@ namespace MudBlazor.UnitTests.Components
                 toolTip.ClassList.Should().Contain(["mud-tooltip"]);
                 toolTip.TextContent.Should().Be("close here");
 
-                await item.ParentElement.TriggerEventAsync("onpointerleave", new PointerEventArgs());
+                await item.ParentElement.PointerLeaveAsync(new PointerEventArgs());
 
             }
 
@@ -136,7 +136,7 @@ namespace MudBlazor.UnitTests.Components
                 var parent = (IHtmlElement)item.Parent;
                 parent.Children.Should().HaveCount(2, because: "the button and the empty popover hint"); ;
 
-                await item.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+                await item.ParentElement.PointerEnterAsync(new PointerEventArgs());
 
                 var popoverId = parent.Children[1].Id.Substring(8);
 
@@ -145,7 +145,7 @@ namespace MudBlazor.UnitTests.Components
                 toolTip.ClassList.Should().Contain(["mud-tooltip"]);
                 toolTip.TextContent.Should().Be("add here");
 
-                await item.ParentElement.TriggerEventAsync("onpointerleave", new PointerEventArgs());
+                await item.ParentElement.PointerLeaveAsync(new PointerEventArgs());
             }
         }
 

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -308,9 +308,9 @@ namespace MudBlazor.UnitTests.Components
             var header = comp.Find(".mud-expand-panel-header");
 
             comp.Markup.Should().NotContain("mud-panel-expanded");
-            await header.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
+            await header.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
             comp.Markup.Should().Contain("mud-panel-expanded");
-            await header.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = " " });
+            await header.KeyDownAsync(new KeyboardEventArgs { Key = " " });
             comp.Markup.Should().NotContain("mud-panel-expanded");
         }
 
@@ -346,11 +346,11 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().NotContain("mud-panel-expanded");
 
             // Try to expand with Enter key - should be ignored
-            await header.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
+            await header.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
             comp.Markup.Should().NotContain("mud-panel-expanded");
 
             // Try to expand with Space key - should be ignored
-            await header.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = " " });
+            await header.KeyDownAsync(new KeyboardEventArgs { Key = " " });
             comp.Markup.Should().NotContain("mud-panel-expanded");
         }
 

--- a/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
@@ -59,16 +59,16 @@ public class FabMenuTests : BunitTest
     {
         var comp = Context.Render<FabMenuTest>(parameters => parameters.Add(p => p.OpenOnMouseHover, true));
 
-        await comp.FindAll(".mud-fab-menu-container")[0].TriggerEventAsync("onmouseenter", new MouseEventArgs());
+        await comp.FindAll(".mud-fab-menu-container")[0].MouseEnterAsync(new MouseEventArgs());
         await comp.WaitForAssertionAsync(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(1); });
 
         await comp.FindAll(".mud-fab-menu-item")[0].ClickAsync();
         await comp.WaitForAssertionAsync(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0); });
 
-        await comp.FindAll(".mud-fab-menu-container")[0].TriggerEventAsync("onmouseenter", new MouseEventArgs());
+        await comp.FindAll(".mud-fab-menu-container")[0].MouseEnterAsync(new MouseEventArgs());
         await comp.WaitForAssertionAsync(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(1); });
 
-        await comp.FindAll(".mud-fab-menu-container")[0].TriggerEventAsync("onmouseleave", new MouseEventArgs());
+        await comp.FindAll(".mud-fab-menu-container")[0].MouseLeaveAsync(new MouseEventArgs());
         await comp.WaitForAssertionAsync(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0); });
     }
 }

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -149,15 +149,15 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().NotContain("mud-popover-open");
 
             // Pointer over to menu to open popover
-            await Menu().TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await Menu().PointerEnterAsync(new PointerEventArgs());
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("mud-popover-open"));
 
             // Popover open, captures pointer
-            await Menu().TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await Menu().PointerLeaveAsync(new PointerEventArgs());
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().NotContain("mud-popover-open"));
 
             // Pointer moves to menu, still need to open
-            await Menu().TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await Menu().PointerEnterAsync(new PointerEventArgs());
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("mud-popover-open"));
         }
 
@@ -185,11 +185,11 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindComponent<MudPopover>().Instance.Open.Should().BeTrue());
 
             // Hover the list shouldn't change anything.
-            await comp.Find("[data-testid='menu-wrapper']").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await comp.Find("[data-testid='menu-wrapper']").PointerEnterAsync(new PointerEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindComponent<MudPopover>().Instance.Open.Should().BeTrue());
 
             // Leave the list shouldn't change anything.
-            await comp.Find("[data-testid='menu-wrapper']").TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await comp.Find("[data-testid='menu-wrapper']").PointerLeaveAsync(new PointerEventArgs());
             await Task.Delay(MudGlobal.MenuDefaults.HoverDelay + 100);
             await comp.WaitForAssertionAsync(() => comp.FindComponent<MudPopover>().Instance.Open.Should().BeTrue());
 
@@ -312,7 +312,7 @@ namespace MudBlazor.UnitTests.Components
             var rightClickMenu = rightClickMenus.FirstOrDefault(m => m.QuerySelector("div[style*='inline-block']") != null);
             var userDiv = rightClickMenu?.QuerySelector("div[style*='inline-block']");
             userDiv.Should().NotBeNull("User's div with contextmenu handler should exist");
-            await userDiv!.TriggerEventAsync("oncontextmenu", new MouseEventArgs() { Button = 2 });
+            await userDiv!.ContextMenuAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -821,18 +821,12 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MenuKeydownTest>();
 
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
             var last = comp.Instance.LastInvokedIndex;
             last.Should().Be(1);
@@ -843,26 +837,16 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MenuKeydownTest>();
 
-            await comp.InvokeAsync(async () =>
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
+
+            var allFocusableItems = comp.FindAll(".mud-menu-item[tabindex='0']");
+
+            if (allFocusableItems.Count > 0)
             {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
-
-            await comp.InvokeAsync(() => Task.CompletedTask);
-
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-
-                var allFocusableItems = comp.FindAll(".mud-menu-item[tabindex='0']");
-
-                if (allFocusableItems.Count > 0)
-                {
-                    var lastItem = allFocusableItems.Last();
-                    await lastItem.ClickAsync(new MouseEventArgs());
-                }
-            });
+                var lastItem = allFocusableItems.Last();
+                await lastItem.ClickAsync(new MouseEventArgs());
+            }
 
             comp.Instance.LastInvokedIndex.Should().Be(6);
         }
@@ -873,28 +857,19 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the menu (focus starts at index -1)
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
             // Press ArrowDown x4 to move to index 3 with nested menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
 
             // Press ArrowRight opens submenu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Should now be 2 open menus: the root and the submenu
             comp.FindAll(".mud-popover-open").Count.Should().BeGreaterThan(1);
@@ -906,18 +881,12 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the menu (focus starts at index 0)
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
             // Press ArrowRight to go back to close menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Ensure the menu hasn't closed
             comp.FindAll(".mud-popover-open").Count.Should().Be(1);
@@ -929,18 +898,12 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the menu (focus starts at index 0)
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
             // Press Arrow Left to close menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft" });
 
             // Ensure all popovers are closed
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
@@ -952,33 +915,24 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
             // Move focus to index 3 and open nested submenu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Ensure we now have more than one menu open
             var openBefore = comp.FindAll(".mud-popover-open");
             openBefore.Count.Should().BeGreaterThan(1);
 
             // Simulate ArrowLeft keypress inside the last opened (nested) menu
-            await comp.InvokeAsync(async () =>
-            {
-                var nestedMenu = comp.FindAll("div[data-testid='menu-wrapper']").Last();
-                await nestedMenu.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
-            });
+            var nestedMenu = comp.FindAll("div[data-testid='menu-wrapper']").Last();
+            await nestedMenu.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft" });
 
             // Assert the submenu was closed (back to just one open popover)
             var openAfter = comp.FindAll(".mud-popover-open");
@@ -991,25 +945,16 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
             // Arrow down to second item (index 1, a link)
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
 
             // Press Enter to enter menu item
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
-            });
+            menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
             // Assert: menu should be closed
             comp.FindAll(".mud-popover-open").Should().BeEmpty();
@@ -1021,28 +966,19 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
             // Arrow into nested menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Press Tab to tab menu item
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Tab" });
-            });
+            menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "Tab" });
 
             // Assert: menu should be closed
             comp.FindAll(".mud-popover-open").Should().BeEmpty();
@@ -1054,29 +990,20 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
             // Arrow into nested menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Press Escape to close submenu
-            await comp.InvokeAsync(async () =>
-            {
-                var nestedWrapper = comp.FindAll("[data-testid='menu-wrapper']").Last();
-                await nestedWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Escape" });
-            });
+            var nestedWrapper = comp.FindAll("[data-testid='menu-wrapper']").Last();
+            await nestedWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
 
             // Only parent menu should remain
             comp.FindAll(".mud-popover-open").Count.Should().Be(1);
@@ -1087,31 +1014,25 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MenuKeydownTest>();
 
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
-            await comp.InvokeAsync(async () =>
-            {
-                // Find the disabled item
-                var disabledItem = comp.Find(".mud-menu-item.mud-disabled");
+            // Find the disabled item
+            var disabledItem = comp.Find(".mud-menu-item.mud-disabled");
 
-                // Verify it has the right accessibility attributes
-                disabledItem.GetAttribute("aria-disabled").Should().Be("true");
-                disabledItem.GetAttribute("tabindex").Should().Be("-1"); // Focusable by script, not by tab
+            // Verify it has the right accessibility attributes
+            disabledItem.GetAttribute("aria-disabled").Should().Be("true");
+            disabledItem.GetAttribute("tabindex").Should().Be("-1"); // Focusable by script, not by tab
 
-                // Verify it's in the DOM and visible for screen readers
-                disabledItem.Should().NotBeNull();
-                disabledItem.TextContent.Should().Contain("5 Disabled");
+            // Verify it's in the DOM and visible for screen readers
+            disabledItem.Should().NotBeNull();
+            disabledItem.TextContent.Should().Contain("5 Disabled");
 
-                // Try to click it - it should NOT invoke the action
-                await disabledItem.ClickAsync(new MouseEventArgs());
+            // Try to click it - it should NOT invoke the action
+            await disabledItem.ClickAsync(new MouseEventArgs());
 
-                // LastInvokedIndex should still be null because disabled items shouldn't invoke
-                comp.Instance.LastInvokedIndex.Should().BeNull();
-            });
+            // LastInvokedIndex should still be null because disabled items shouldn't invoke
+            comp.Instance.LastInvokedIndex.Should().BeNull();
         }
 
         [Test]
@@ -1119,11 +1040,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MenuKeydownTest>();
 
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            var menuButton = comp.Find(".mud-menu-button-activator");
+            await menuButton.ClickAsync(new MouseEventArgs());
 
             await comp.InvokeAsync(() =>
             {
@@ -1169,11 +1087,8 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.FindComponent<MudMenu>().Instance;
 
             // Open the menu through its activator
-            await comp.InvokeAsync(async () =>
-            {
-                var button = comp.Find(".mud-menu-button-activator");
-                await button.ClickAsync(new MouseEventArgs());
-            });
+            var button = comp.Find(".mud-menu-button-activator");
+            await button.ClickAsync(new MouseEventArgs());
 
             // Simulate ArrowDown to move focus to the first item
             await comp.InvokeAsync(() =>
@@ -1198,11 +1113,8 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.FindComponent<MudMenu>().Instance;
 
             // Open the menu through its activator
-            await comp.InvokeAsync(async () =>
-            {
-                var button = comp.Find(".mud-menu-button-activator");
-                await button.ClickAsync(new MouseEventArgs());
-            });
+            var button = comp.Find(".mud-menu-button-activator");
+            await button.ClickAsync(new MouseEventArgs());
 
             // Simulate ArrowUp to move focus to the last item
             await comp.InvokeAsync(() =>

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -210,12 +210,12 @@ namespace MudBlazor.UnitTests.Components
             var inputs = comp.FindAll("input");
             inputs.Count.Should().Be(3);
             inputs[1].GetAttribute("value").Should().Be("Value2");
-            await inputs[1].TriggerEventAsync("onmousedown", new MouseEventArgs());
+            await inputs[1].MouseDownAsync(new MouseEventArgs());
             await Task.Delay(500);
             var listItems = comp.FindAll(".mud-list-item");
             foreach (var listItem in listItems)
             {
-                await listItem.TriggerEventAsync("onclick", new MouseEventArgs());
+                await listItem.ClickAsync(new MouseEventArgs());
             }
 
             inputs = comp.FindAll("input");
@@ -809,22 +809,16 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
 
             // Open select
-            await comp.InvokeAsync(async () =>
-            {
-                var input = comp.Find("div.mud-input-control");
-                await input.MouseDownAsync();
-            });
+            var input = comp.Find("div.mud-input-control");
+            await input.MouseDownAsync();
 
             // Wait for items to render
             await comp.WaitForAssertionAsync(() =>
                 comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
 
             // Select second item
-            await comp.InvokeAsync(async () =>
-            {
-                var items = comp.FindAll("div.mud-list-item");
-                await items[1].ClickAsync();
-            });
+            var items = comp.FindAll("div.mud-list-item");
+            await items[1].ClickAsync();
 
             // Popover closes
             await comp.WaitForAssertionAsync(() =>
@@ -838,11 +832,8 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-input-clear-button").Should().ContainSingle();
 
             // Click clear button
-            await comp.InvokeAsync(async () =>
-            {
-                var clearButton = comp.Find(".mud-input-clear-button");
-                await clearButton.ClickAsync();
-            });
+            var clearButton = comp.Find(".mud-input-clear-button");
+            await clearButton.ClickAsync();
 
             // Value cleared
             await comp.WaitForAssertionAsync(() =>

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -432,7 +432,7 @@ namespace MudBlazor.UnitTests.Components
             // Test that clicking the snackbar will trigger onclick to close despite pointer over and touch start pausing it.
 
             _provider.Find(".mud-snackbar").TouchStart();
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
             await _provider.Find(".mud-snackbar").ClickAsync();
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
@@ -455,7 +455,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Test that clicking the close button will actually close the snackbar even with the pointer over.
 
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
             await _provider.FindAll(".mud-snackbar-close-button").Single().ClickAsync();
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
@@ -508,7 +508,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Test that clicking the action button will actually close the snackbar even with the pointer over.
 
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
             await _provider.Find(".mud-snackbar-action-button").ClickAsync();
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
@@ -583,7 +583,7 @@ namespace MudBlazor.UnitTests.Components
 
             await _provider.Find(".mud-snackbar-close-button").ClickAsync();
             _provider.Find(".mud-snackbar").TouchStart();
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -609,13 +609,13 @@ namespace MudBlazor.UnitTests.Components
 
             // Test that the snackbar will stay visible.
 
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
 
             await Task.Delay(primary.State.Options.VisibleStateDuration * 2);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -675,7 +675,7 @@ namespace MudBlazor.UnitTests.Components
             // Interrupting show transition should instantly go to visible state.
 
             primary.State.SnackbarState.Should().Be(SnackbarState.Showing);
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
 
             // Pointer is still over and the state should still be visible.
@@ -684,16 +684,16 @@ namespace MudBlazor.UnitTests.Components
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // Leave pointer and let the hide transition that's been pending start.
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
             await Task.Delay(primary.State.Options.HideTransitionDuration / 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Hiding);
 
             // Re-enter halfway through hide transition.
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
 
             // Finally make the pointer leave and let it hide.
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 
@@ -719,12 +719,12 @@ namespace MudBlazor.UnitTests.Components
             // Force it out of the show transition.
 
             primary.State.SnackbarState.Should().Be(SnackbarState.Showing);
-            _provider.Find(".mud-snackbar").TriggerEvent("onpointerenter", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
 
             // Ensure that leaving with the pointer does not trigger a hide transition by itself, like if the timer was not properly utilized.
 
-            _provider.Find(".mud-snackbar").TriggerEvent("onpointerleave", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
             await Task.Delay(primary.State.Options.VisibleStateDuration / 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
@@ -752,8 +752,8 @@ namespace MudBlazor.UnitTests.Components
             // Prove that the pointer entering the snackbar does not restart the duration from zero.
 
             await Task.Delay(60); // 60% through the visible duration.
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
-            await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
+            await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
             _provider.Find(".mud-snackbar").TouchStart();
             _provider.Find(".mud-snackbar").TouchEnd();
 
@@ -789,14 +789,11 @@ namespace MudBlazor.UnitTests.Components
                 var clicked = false;
 
                 // Click the action button if one was found.
-                await _provider.InvokeAsync(async () =>
+                if (_provider.FindAll(".mud-snackbar-action-button").Count == 1)
                 {
-                    if (_provider.FindAll(".mud-snackbar-action-button").Count == 1)
-                    {
-                        await _provider.Find(".mud-snackbar-action-button").ClickAsync();
-                        clicked = true;
-                    }
-                });
+                    await _provider.Find(".mud-snackbar-action-button").ClickAsync();
+                    clicked = true;
+                }
 
                 if (clicked)
                     clickAttempts++;
@@ -835,14 +832,11 @@ namespace MudBlazor.UnitTests.Components
                 var clicked = false;
 
                 // Click the snackbar if one was found.
-                await _provider.InvokeAsync(async () =>
+                if (_provider.FindAll(".mud-snackbar").Count == 1)
                 {
-                    if (_provider.FindAll(".mud-snackbar").Count == 1)
-                    {
-                        await _provider.Find(".mud-snackbar").ClickAsync();
-                        clicked = true;
-                    }
-                });
+                    await _provider.Find(".mud-snackbar").ClickAsync();
+                    clicked = true;
+                }
 
                 if (clicked)
                     clickAttempts++;

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -56,22 +56,22 @@ namespace MudBlazor.UnitTests.Components
 
             var trs = comp.FindAll("tr");
 
-            await trs[0].TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await trs[0].PointerEnterAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: 'A', last: ''");
 
-            await trs[0].TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await trs[0].PointerLeaveAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: 'A'");
 
-            await trs[1].TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await trs[1].PointerEnterAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: 'B', last: 'A'");
 
-            await trs[1].TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await trs[1].PointerLeaveAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: 'B'");
 
-            await trs[0].TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await trs[0].PointerEnterAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: 'A', last: 'B'");
 
-            await trs[0].TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await trs[0].PointerLeaveAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: 'A'");
         }
 
@@ -3074,4 +3074,3 @@ namespace MudBlazor.UnitTests.Components
 
     }
 }
-

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1591,28 +1591,16 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<TabsKeyboardAccessibilityTest>();
             comp.Find("div.mud-tabs-panels").InnerHtml.Should().Contain("Content One");
 
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[0].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            var tabs = comp.FindAll("div.mud-tab");
+            await tabs[0].KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
             var tabsAfterArrowRight = comp.FindAll("div.mud-tab");
-            await comp.InvokeAsync(async () =>
-            {
-                await tabsAfterArrowRight[1].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
-            });
+            await tabsAfterArrowRight[1].KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
             comp.Find("div.mud-tabs-panels").InnerHtml.Should().Contain("Content Two");
 
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[1].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
-            });
+            tabs = comp.FindAll("div.mud-tab");
+            await tabs[1].KeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft" });
             var tabsAfterArrowLeft = comp.FindAll("div.mud-tab");
-            await comp.InvokeAsync(async () =>
-            {
-                await tabsAfterArrowLeft[0].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = " " });
-            });
+            await tabsAfterArrowLeft[0].KeyDownAsync(new KeyboardEventArgs { Key = " " });
             comp.Find("div.mud-tabs-panels").InnerHtml.Should().Contain("Content One");
         }
 
@@ -1623,30 +1611,18 @@ namespace MudBlazor.UnitTests.Components
         public async Task VerticalTabs_SupportsArrowUpDownNavigation()
         {
             var comp = Context.Render<VerticalTabsKeyboardAccessibilityTest>();
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[0].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            });
+            var tabs = comp.FindAll("div.mud-tab");
+            await tabs[0].KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
 
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[1].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
-            });
+            tabs = comp.FindAll("div.mud-tab");
+            await tabs[1].KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
             comp.Find("div.mud-tabs-panels").InnerHtml.Should().Contain("Content Two");
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[1].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            });
+            tabs = comp.FindAll("div.mud-tab");
+            await tabs[1].KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
 
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[2].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = " " });
-            });
+            tabs = comp.FindAll("div.mud-tab");
+            await tabs[2].KeyDownAsync(new KeyboardEventArgs { Key = " " });
             comp.Find("div.mud-tabs-panels").InnerHtml.Should().Contain("Content Three");
         }
 
@@ -1657,30 +1633,18 @@ namespace MudBlazor.UnitTests.Components
         public async Task KeyboardNavigation_LeftArrow_WrapsToLastEnabledTab()
         {
             var comp = Context.Render<TabsKeyboardAccessibilityTest>();
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[0].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
-            });
+            var tabs = comp.FindAll("div.mud-tab");
+            await tabs[0].KeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft" });
 
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[1].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
-            });
+            tabs = comp.FindAll("div.mud-tab");
+            await tabs[1].KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
             comp.Find("div.mud-tabs-panels").InnerHtml.Should().Contain("Content Two");
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[1].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
-            });
+            tabs = comp.FindAll("div.mud-tab");
+            await tabs[1].KeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft" });
 
-            await comp.InvokeAsync(async () =>
-            {
-                var tabs = comp.FindAll("div.mud-tab");
-                await tabs[0].TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = " " });
-            });
+            tabs = comp.FindAll("div.mud-tab");
+            await tabs[0].KeyDownAsync(new KeyboardEventArgs { Key = " " });
             comp.Find("div.mud-tabs-panels").InnerHtml.Should().Contain("Content One");
         }
 
@@ -1815,7 +1779,7 @@ namespace MudBlazor.UnitTests.Components
             var tabs = comp.FindAll("div.mud-tab");
             tabs.Count.Should().Be(6);
 
-            await tabs[1].TriggerEventAsync("onmousedown", new MouseEventArgs { Button = 1 });
+            await tabs[1].MouseDownAsync(new MouseEventArgs { Button = 1 });
 
             comp.FindAll("div.mud-tab").Count
                 .Should().Be(5);
@@ -1824,7 +1788,7 @@ namespace MudBlazor.UnitTests.Components
             tabs = comp.FindAll("div.mud-tab");
             tabs.Count.Should().Be(5);
 
-            await tabs[1].TriggerEventAsync("oncontextmenu", default);
+            await tabs[1].ContextMenuAsync(default);
 
             var menuItems = comp.FindComponents<MudMenuItem>();
             menuItems.Count.Should().Be(3);
@@ -1835,7 +1799,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Close All tabs.
             tabs = comp.FindAll("div.mud-tab");
-            await tabs[0].TriggerEventAsync("oncontextmenu", default);
+            await tabs[0].ContextMenuAsync(default);
 
             await comp.FindComponents<MudMenuItem>()[1].Find(".mud-menu-item").ClickAsync();
 

--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -57,7 +57,7 @@ namespace MudBlazor.UnitTests.Components
             tooltipComp.GetState(x => x.Visible).Should().BeFalse();
 
             //trigger pointerover
-            await button.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
 
             popoverContentNode().TextContent.Should().Be("my tooltip content text");
             popoverContentNode().ClassList.Should().Contain("d-flex");
@@ -67,7 +67,7 @@ namespace MudBlazor.UnitTests.Components
             //trigger pointerleave
             if (!usingFocusout)
             {
-                await button.ParentElement.TriggerEventAsync("onpointerleave", new PointerEventArgs());
+                await button.ParentElement.PointerLeaveAsync(new PointerEventArgs());
             }
             else
             {
@@ -121,7 +121,7 @@ namespace MudBlazor.UnitTests.Components
             popoverContentNode.Children.Should().BeEmpty();
 
             //trigger pointerover
-            await button.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
 
             //content should be visible
             popoverContentNode.ClassList.Should().Contain("mud-tooltip");
@@ -132,7 +132,7 @@ namespace MudBlazor.UnitTests.Components
             //trigger pointerleave
             if (!usingFocusout)
             {
-                await button.ParentElement.TriggerEventAsync("onpointerleave", new PointerEventArgs());
+                await button.ParentElement.PointerLeaveAsync(new PointerEventArgs());
             }
             else
             {
@@ -163,7 +163,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<ToolTipPopoverClassPropertyTest>();
 
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
 
             var wrapperDivNode = comp.Find("#my-tooltip-content").ParentElement;
 
@@ -179,7 +179,7 @@ namespace MudBlazor.UnitTests.Components
             p.Add(x => x.Arrow, arrowValue));
 
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
@@ -197,7 +197,7 @@ namespace MudBlazor.UnitTests.Components
             p.Add(x => x.Color, colorValue));
 
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
@@ -218,7 +218,7 @@ namespace MudBlazor.UnitTests.Components
             });
 
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
@@ -248,7 +248,7 @@ namespace MudBlazor.UnitTests.Components
             });
 
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
@@ -261,7 +261,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<ToolTipPlacementPropertyTest>();
 
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onfocusin", new FocusEventArgs());
+            await button.ParentElement.FocusInAsync(new FocusEventArgs());
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement;
 
@@ -275,7 +275,7 @@ namespace MudBlazor.UnitTests.Components
             var tooltipComp = comp.FindComponent<MudTooltip>().Instance;
             tooltipComp.Visible.Should().BeFalse();
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onpointerup", new PointerEventArgs());
+            await button.ParentElement.PointerUpAsync(new PointerEventArgs());
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement;
             tooltipComp.GetState(x => x.Visible).Should().BeTrue();
@@ -300,7 +300,7 @@ namespace MudBlazor.UnitTests.Components
 
             if (!usingFocusout)
             {
-                await button.ParentElement.TriggerEventAsync("onpointerleave", new PointerEventArgs());
+                await button.ParentElement.PointerLeaveAsync(new PointerEventArgs());
             }
             else
             {
@@ -317,7 +317,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<TestComponents.Tooltip.TooltipStylingTest>();
             var tooltipComp = comp.FindComponent<MudTooltip>().Instance;
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onpointerup", new PointerEventArgs());
+            await button.ParentElement.PointerUpAsync(new PointerEventArgs());
 
             tooltipComp.Style.Should().Contain("background-color").And.Contain("orangered");
         }
@@ -339,7 +339,7 @@ namespace MudBlazor.UnitTests.Components
             });
 
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onfocusin", new FocusEventArgs());
+            await button.ParentElement.FocusInAsync(new FocusEventArgs());
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
 
@@ -352,7 +352,7 @@ namespace MudBlazor.UnitTests.Components
             });
 
             var button = comp.Find("button");
-            await button.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
 


### PR DESCRIPTION
### Motivation
- Modernize tests to use bUnit's specific async event helpers instead of generic `TriggerEvent`/`TriggerEventAsync` so events are dispatched via the intended API. 
- Remove redundant `InvokeAsync` wrappers around element interactions when the inner call is already an async bUnit method to avoid stale handler IDs and simplify tests. 

### Description
- Replaced generic calls like `TriggerEvent`/`TriggerEventAsync` with targeted bUnit helpers such as `PointerEnterAsync`/`PointerLeaveAsync`, `MouseOverAsync`/`MouseOutAsync`, `ClickAsync`, `KeyDownAsync`, `ContextMenuAsync`, `MouseDownAsync`, `FocusInAsync`, `PointerUpAsync`, `MouseEnterAsync` and `MouseLeaveAsync` where the helper exists. 
- Removed unnecessary `await comp.InvokeAsync(async () => { ... await element.ClickAsync(); })` wrappers and simplified to direct `await element.ClickAsync()` or equivalent bUnit async helper calls. 
- Kept renderer-level `InvokeAsync` usages (component instance calls) where appropriate and preserved cases that must run on the test renderer. 
- Applied changes across unit tests including (but not limited to) `MenuTests`, `TabsTests`, `SelectTests`, `DataGridTests`, `SnackbarTests`, `TableTests`, `ToolTipTests`, chart tests and date picker/range tests to ensure consistent event dispatch patterns. 

### Testing
- Attempted to run the required formatting command `dotnet format src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --include ...` but `dotnet` was not available in the environment, so formatting and any `dotnet`-based automated test runs could not be executed. 
- No automated unit test runs were performed in this environment due to the missing .NET SDK, so test success/failure is unverified here. 
- Static validation performed: code changes were applied and compiled format tooling was attempted; developer should run `dotnet build` and `dotnet test` (targeting affected projects) and `dotnet format` locally or in CI to validate formatting and test-suite results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977e34782d883288cd6de1f5fea0789)