### PR TITLE
Remove `[NonParallelizable]` from HiddenTests fixture

### DIFF
--- a/src/MudBlazor.UnitTests/Components/HiddenTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HiddenTests.cs
@@ -13,7 +13,6 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
-    [NonParallelizable]
     public class HiddenTests : BunitTest
     {
         [Test]


### PR DESCRIPTION
### Motivation
- Allow the `HiddenTests` fixture to run in parallel with other tests because the test file contains no shared/static state and follows the project's bUnit parallelization guidance.

### Description
- Remove the `[NonParallelizable]` attribute from the `HiddenTests` class in `src/MudBlazor.UnitTests/Components/HiddenTests.cs` so the fixture can be executed in parallel.

### Testing
- No automated tests were executed in this environment because `dotnet` was unavailable; formatting and test runs were attempted but could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783c1d6cf8832891b30e03a3be8179)