### PR TITLE
Inline single-use FindAll calls in unit tests

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1577,11 +1577,10 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be(1);
             numeric.Should().Be(comp.Instance.FormFieldChangedEventArgs.Field);
 
-            var inputs = comp.FindAll("input").ToArray();
             // check initial state
             radioGroup.Value.Should().Be(null);
             // click radio 1
-            await inputs[2].ClickAsync();
+            await comp.FindAll("input")[2].ClickAsync();
             radioGroup.Value.Should().Be("1");
             comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be("1");
             radioGroup.Should().Be(comp.Instance.FormFieldChangedEventArgs.Field);

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -1,4 +1,5 @@
-﻿using AwesomeAssertions;
+﻿using AngleSharp.Dom;
+using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.RadioGroup;
@@ -34,7 +35,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<RadioGroupTest1>();
             // select elements needed for the test
             var group = comp.FindComponent<MudRadioGroup<string>>();
-            var inputs = comp.FindAll("input").ToArray();
+            IReadOnlyList<IElement> Inputs() => comp.FindAll("input");
 
             // check initial state
             group.Instance.Value.Should().Be(null);
@@ -42,28 +43,28 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-radio > span.mud-icon-button")[1].ClassList.Should().NotContain("mud-checked");
             comp.FindAll(".mud-radio > span.mud-icon-button")[2].ClassList.Should().NotContain("mud-checked");
             // click radio 1
-            await inputs[0].ClickAsync();
+            await Inputs()[0].ClickAsync();
             group.Instance.Value.Should().Be("1");
 
             comp.FindAll(".mud-radio > span.mud-icon-button")[0].ClassList.Should().Contain("mud-checked");
             comp.FindAll(".mud-radio > span.mud-icon-button")[1].ClassList.Should().NotContain("mud-checked");
             comp.FindAll(".mud-radio > span.mud-icon-button")[2].ClassList.Should().NotContain("mud-checked");
             // click radio 2
-            await inputs[1].ClickAsync();
+            await Inputs()[1].ClickAsync();
             group.Instance.Value.Should().Be("2");
 
             comp.FindAll(".mud-radio > span.mud-icon-button")[0].ClassList.Should().NotContain("mud-checked");
             comp.FindAll(".mud-radio > span.mud-icon-button")[1].ClassList.Should().Contain("mud-checked");
             comp.FindAll(".mud-radio > span.mud-icon-button")[2].ClassList.Should().NotContain("mud-checked");
             // click radio 3
-            await inputs[2].ClickAsync();
+            await Inputs()[2].ClickAsync();
             group.Instance.Value.Should().Be("3");
 
             comp.FindAll(".mud-radio > span.mud-icon-button")[0].ClassList.Should().NotContain("mud-checked");
             comp.FindAll(".mud-radio > span.mud-icon-button")[1].ClassList.Should().NotContain("mud-checked");
             comp.FindAll(".mud-radio > span.mud-icon-button")[2].ClassList.Should().Contain("mud-checked");
             // click radio 1
-            await inputs[0].ClickAsync();
+            await Inputs()[0].ClickAsync();
             group.Instance.Value.Should().Be("1");
 
             comp.FindAll(".mud-radio > span.mud-icon-button")[0].ClassList.Should().Contain("mud-checked");
@@ -90,7 +91,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<RadioGroupTest3>();
             // select elements needed for the test
             var groups = comp.FindComponents<MudRadioGroup<string>>();
-            var inputs = comp.FindAll("input").ToArray();
+            IReadOnlyList<IElement> Inputs() => comp.FindAll("input");
 
             // check initial state, should be initialized to second radio by default for both groups
             groups[0].Instance.Value.Should().Be("2");
@@ -100,7 +101,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-radio > span.mud-icon-button")[2].ClassList.Should().NotContain("mud-checked");
             comp.FindAll(".mud-radio > span.mud-icon-button")[3].ClassList.Should().Contain("mud-checked");
             // click first radio of second group - they should both switch to L1
-            await inputs[2].ClickAsync();
+            await Inputs()[2].ClickAsync();
 
             groups[0].Instance.Value.Should().Be("1");
             groups[1].Instance.Value.Should().Be("1");
@@ -109,7 +110,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-radio > span.mud-icon-button")[2].ClassList.Should().Contain("mud-checked");
             comp.FindAll(".mud-radio > span.mud-icon-button")[3].ClassList.Should().NotContain("mud-checked");
             // click second radio of first group - they should both switch to L1
-            await inputs[1].ClickAsync();
+            await Inputs()[1].ClickAsync();
 
             groups[0].Instance.Value.Should().Be("2");
             groups[1].Instance.Value.Should().Be("2");
@@ -204,10 +205,9 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<RadioGroupTest5>();
             // select elements needed for the test
             var group = comp.FindComponent<MudRadioGroup<string>>();
-            var inputs = comp.FindAll("input").ToArray();
 
             //Value should change on radio click and bind after should fire
-            await inputs[1].ClickAsync();
+            await comp.FindAll("input")[1].ClickAsync();
             group.Instance.Value.Should().Be("2");
             comp.Instance.BindAfterCount.Should().Be(1);
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -106,12 +106,13 @@ namespace MudBlazor.UnitTests.Components
             await Input().MouseDownAsync();
             menu.ClassList.Should().Contain("mud-popover-open");
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            var items = comp.FindAll("div.mud-list-item").ToArray();
+            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
+            var items = Items();
             items[0].TextContent.Should().Be("Cardinale");
             items[1].TextContent.Should().Be("Diavolo");
             items[2].TextContent.Should().Be("Margarita");
             items[3].TextContent.Should().Be("Spinaci");
-            await items[2].ClickAsync();
+            await Items()[2].ClickAsync();
             Input().GetAttribute("value").Should().Be("Margarita");
         }
 
@@ -242,8 +243,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Attributes["value"]?.Value.Should().Be("First");
             await input.MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync();
+            await comp.FindAll("div.mud-list-item")[1].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("input").Attributes["value"]?.Value.Should().Be("Second"));
         }
 
@@ -262,8 +262,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Attributes["value"]?.Value.Should().Be("17");
             await input.MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync();
+            await comp.FindAll("div.mud-list-item")[1].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-input-slot").TextContent.Trim().Should().Be("Two"));
             select.Instance.ReadValue.Should().Be(2);
             select.Instance.ReadText.Should().Be("2");
@@ -288,8 +287,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Hidden);
             await input.MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync();
+            await comp.FindAll("div.mud-list-item")[1].ClickAsync();
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be(2));
             select.Instance.ReadText.Should().Be("2");
             comp.FindComponent<MudInput<string>>().Instance.ReadValue.Should().Be("2");
@@ -313,7 +311,7 @@ namespace MudBlazor.UnitTests.Components
             // Open menu and select a non-null value
             await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            await comp.FindAll("div.mud-list-item").ToArray()[1].ClickAsync(); // Select "One" (value = 1)
+            await comp.FindAll("div.mud-list-item")[1].ClickAsync(); // Select "One" (value = 1)
 
             // Verify non-null value
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be(1));
@@ -323,7 +321,7 @@ namespace MudBlazor.UnitTests.Components
             // Open menu again and select null value
             await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            await comp.FindAll("div.mud-list-item").ToArray()[0].ClickAsync(); // Select "None" (value = null)
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync(); // Select "None" (value = null)
 
             // Verify back to null value
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be(null));
@@ -407,8 +405,7 @@ namespace MudBlazor.UnitTests.Components
 
             await input.MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync();
+            await comp.FindAll("div.mud-list-item")[1].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:none"));
             select.Instance.ReadValue.Should().Be(2);
@@ -432,8 +429,8 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync();
+            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
+            await Items()[1].ClickAsync();
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
@@ -443,9 +440,7 @@ namespace MudBlazor.UnitTests.Components
             //open the menu again
             await input.MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            items = comp.FindAll("div.mud-list-item").ToArray();
-
-            await items[0].ClickAsync();
+            await Items()[0].ClickAsync();
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
             select.Instance.ReadText.Should().Be("1");
             text.Should().Be("1");
@@ -487,8 +482,8 @@ namespace MudBlazor.UnitTests.Components
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync();
+            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
+            await Items()[1].ClickAsync();
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
@@ -500,9 +495,7 @@ namespace MudBlazor.UnitTests.Components
 
             await input.MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            items = comp.FindAll("div.mud-list-item").ToArray();
-
-            await items[0].ClickAsync();
+            await Items()[0].ClickAsync();
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
             select.Instance.ReadText.Should().Be("1");
             text.Should().Be("1");
@@ -541,9 +534,9 @@ namespace MudBlazor.UnitTests.Components
             var selectElement = comp.Find("div.mud-input-control");
             await selectElement.MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            var items = comp.FindAll("div.mud-list-item").ToArray();
             // click list item
-            await items[1].ClickAsync();
+            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
+            await Items()[1].ClickAsync();
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
             select.Instance.ReadText.Should().Be("2");
             text.Should().Be("2");
@@ -552,8 +545,7 @@ namespace MudBlazor.UnitTests.Components
             string.Join(",", selectedValues).Should().Be("2");
             // click another list item
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[0].ClickAsync();
+            await Items()[0].ClickAsync();
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2, 1"));
             select.Instance.ReadText.Should().Be("2, 1");
             text.Should().Be("2, 1");
@@ -711,16 +703,16 @@ namespace MudBlazor.UnitTests.Components
             await input.MouseDownAsync(new MouseEventArgs());
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click the first checkbox to select all
-            var items = comp.FindAll("div.mud-list-item").ToArray();
             select.Instance.GetState(x => x.SelectedValues).Should().HaveCount(0);
-            await items[0].ClickAsync();
+            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
+            await Items()[0].ClickAsync();
             // validate the result. all items that are not disabled should be selected
             await comp.WaitForAssertionAsync(() => select.Instance.GetState(x => x.SelectedValues).Should().HaveCount(3));
             select.Instance.GetState(x => x.SelectedValues).ElementAt(0).Should().Be("FirstA");
             select.Instance.GetState(x => x.SelectedValues).ElementAt(1).Should().Be("SecondA");
             select.Instance.GetState(x => x.SelectedValues).ElementAt(2).Should().Be("ThirdA");
             // now click the first checkbox again to unselect all
-            await items[0].ClickAsync();
+            await Items()[0].ClickAsync();
             // validate the result. all items should be un-selected
             await comp.WaitForAssertionAsync(() => select.Instance.GetState(x => x.SelectedValues).Should().HaveCount(0));
         }
@@ -822,8 +814,7 @@ namespace MudBlazor.UnitTests.Components
             // Select second item
             await comp.InvokeAsync(async () =>
             {
-                var items = comp.FindAll("div.mud-list-item");
-                await items[1].ClickAsync();
+                await comp.FindAll("div.mud-list-item")[1].ClickAsync();
             });
 
             // Popover closes
@@ -870,8 +861,8 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadValue.Should().Be("Apple");
 
             // now click an item and see the value change
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync();
+            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
+            await Items()[1].ClickAsync();
 
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => menu.ClassList.Should().NotContain("mud-popover-open"));
@@ -881,8 +872,7 @@ namespace MudBlazor.UnitTests.Components
             // now click an item and see the value change
             await input.MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync();
+            await Items()[1].ClickAsync();
 
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Orange"));
             comp.Instance.ChangeCount.Should().Be(1);
@@ -1242,9 +1232,9 @@ namespace MudBlazor.UnitTests.Components
             var mudSelectElement = comp.Find(".mud-select");
             await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
             select.Instance._open.Should().BeTrue();
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[0].ClickAsync();
-            await items[2].ClickAsync();
+            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
+            await Items()[0].ClickAsync();
+            await Items()[2].ClickAsync();
             //emulate focus out
             mudSelectElement.FocusOut();
             await comp.WaitForAssertionAsync(() => select.Instance.ReadText.Should().Be("Alaska, Alabama, American Samoa"));
@@ -1327,8 +1317,8 @@ namespace MudBlazor.UnitTests.Components
             //2a. Now check when SelectedItems is greater than one - Validation Should Pass
             var inputs = comp.FindAll("div.mud-input-control");
             await inputs[0].MouseDownAsync(new MouseEventArgs());//The 2nd one is the
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync();
+            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
+            await Items()[1].ClickAsync();
             await comp.InvokeAsync(() => select.ValidateAsync());
             select.ValidationErrors.Count.Should().Be(0);
 
@@ -1336,8 +1326,7 @@ namespace MudBlazor.UnitTests.Components
             await inputs[1].MouseDownAsync(new MouseEventArgs());//selectWithT
             //wait for render and it will find 5 items from the component
             comp.WaitForState(() => comp.FindAll("div.mud-list-item").Count == 5);
-            items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[3].ClickAsync();
+            await Items()[3].ClickAsync();
             await comp.InvokeAsync(() => selectWithT.ValidateAsync());
             selectWithT.ValidationErrors.Count.Should().Be(0);
         }
@@ -1361,8 +1350,8 @@ namespace MudBlazor.UnitTests.Components
             var inputs = comp.FindAll("div.mud-input-control");
             await inputs[0].MouseDownAsync(new MouseEventArgs());
 
-            var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync(new MouseEventArgs());
+            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
+            await Items()[1].ClickAsync(new MouseEventArgs());
             await inputs[0].MouseDownAsync(new MouseEventArgs());
             select.Value.Should().Be("2");
             select.GetState(x => x.SelectedValues).Should().Contain("2");
@@ -1376,8 +1365,7 @@ namespace MudBlazor.UnitTests.Components
             //test resetting string values
             inputs = comp.FindAll("div.mud-input-control");
             await inputs[0].MouseDownAsync(new MouseEventArgs());
-            items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync(new MouseEventArgs());
+            await Items()[1].ClickAsync(new MouseEventArgs());
             await inputs[0].MouseDownAsync(new MouseEventArgs());
             select.Value.Should().Be("2");
             select.GetState(x => x.SelectedValues).Should().Contain("2");
@@ -1403,8 +1391,7 @@ namespace MudBlazor.UnitTests.Components
             inputs = comp.FindAll("div.mud-input-control");
             await inputs[1].MouseDownAsync(new MouseEventArgs());
 
-            items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync(new MouseEventArgs());
+            await Items()[1].ClickAsync(new MouseEventArgs());
             await inputs[1].MouseDownAsync(new MouseEventArgs());
             select2.SelectedValues.Select(x => x.Name).Should().Contain("Customer");
 
@@ -1416,8 +1403,7 @@ namespace MudBlazor.UnitTests.Components
             //test resetting object values
             inputs = comp.FindAll("div.mud-input-control");
             await inputs[1].MouseDownAsync(new MouseEventArgs());
-            items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync(new MouseEventArgs());
+            await Items()[1].ClickAsync(new MouseEventArgs());
             await inputs[1].MouseDownAsync(new MouseEventArgs());
             select2.SelectedValues.Select(x => x.Name).Should().Contain("Customer");
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -106,13 +106,12 @@ namespace MudBlazor.UnitTests.Components
             await Input().MouseDownAsync();
             menu.ClassList.Should().Contain("mud-popover-open");
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            IReadOnlyList<IElement> Items() => comp.FindAll("div.mud-list-item");
-            var items = Items();
+            var items = comp.FindAll("div.mud-list-item").ToArray();
             items[0].TextContent.Should().Be("Cardinale");
             items[1].TextContent.Should().Be("Diavolo");
             items[2].TextContent.Should().Be("Margarita");
             items[3].TextContent.Should().Be("Spinaci");
-            await Items()[2].ClickAsync();
+            await items[2].ClickAsync();
             Input().GetAttribute("value").Should().Be("Margarita");
         }
 

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -32,16 +32,15 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<TableRowClickTest>();
             comp.Find("p").TextContent.Trim().Should().BeEmpty();
-            var trs = comp.FindAll("tr");
-            await trs[1].ClickAsync();
+            await comp.FindAll("tr")[1].ClickAsync();
             comp.Find("p").TextContent.Trim().Should().Be("0");
-            await trs[1].ClickAsync();
+            await comp.FindAll("tr")[1].ClickAsync();
             comp.Find("p").TextContent.Trim().Should().Be("0,0");
-            await trs[2].ClickAsync();
+            await comp.FindAll("tr")[2].ClickAsync();
             comp.Find("p").TextContent.Trim().Should().Be("0,0,1");
-            await trs[0].ClickAsync(); // clicking the header should add -1
+            await comp.FindAll("tr")[0].ClickAsync(); // clicking the header should add -1
             comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1");
-            await trs[4].ClickAsync(); // clicking the header should add 100
+            await comp.FindAll("tr")[4].ClickAsync(); // clicking the header should add 100
             comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1,100");
         }
 
@@ -54,24 +53,22 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<TableRowHoverTest>();
             comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: ''");
 
-            var trs = comp.FindAll("tr");
-
-            await trs[0].PointerEnterAsync(new PointerEventArgs());
+            await comp.FindAll("tr")[0].PointerEnterAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: 'A', last: ''");
 
-            await trs[0].PointerLeaveAsync(new PointerEventArgs());
+            await comp.FindAll("tr")[0].PointerLeaveAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: 'A'");
 
-            await trs[1].PointerEnterAsync(new PointerEventArgs());
+            await comp.FindAll("tr")[1].PointerEnterAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: 'B', last: 'A'");
 
-            await trs[1].PointerLeaveAsync(new PointerEventArgs());
+            await comp.FindAll("tr")[1].PointerLeaveAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: 'B'");
 
-            await trs[0].PointerEnterAsync(new PointerEventArgs());
+            await comp.FindAll("tr")[0].PointerEnterAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: 'A', last: 'B'");
 
-            await trs[0].PointerLeaveAsync(new PointerEventArgs());
+            await comp.FindAll("tr")[0].PointerLeaveAsync(new PointerEventArgs());
             comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: 'A'");
         }
 
@@ -334,15 +331,14 @@ namespace MudBlazor.UnitTests.Components
             var table = comp.FindComponent<MudTable<int?>>().Instance;
             table.SelectedItem.Should().BeNull();
             table.SelectedItems.Count.Should().Be(0);
-            var trs = comp.FindAll("tr");
             // Click on row 1 (index 0)
-            await trs[0].ClickAsync();
+            await comp.FindAll("tr")[0].ClickAsync();
             // Check SelectedItem and SelectedItems count
             table.SelectedItem.Should().Be(0);
             table.SelectedItems.Count.Should().Be(1);
             table.SelectedItems.First().Should().Be(0);
             // Repeat
-            await trs[2].ClickAsync();
+            await comp.FindAll("tr")[2].ClickAsync();
             table.SelectedItem.Should().Be(2);
             table.SelectedItems.Count.Should().Be(1);
             table.SelectedItems.First().Should().Be(2);
@@ -661,19 +657,19 @@ namespace MudBlazor.UnitTests.Components
         public async Task TableMultiSelection_CheckboxAndRowClick()
         {
             var comp = Context.Render<TableMultiSelection_CheckboxAndRowClickTest>();
-            var checkboxes = comp.FindComponent<MudTable<int>>().FindAll("input").ToArray();
             var table = comp.FindComponent<MudTable<int>>().Instance;
+            IReadOnlyList<IElement> Checkboxes() => comp.FindComponent<MudTable<int>>().FindAll("input");
 
-            foreach (var cbx in checkboxes)
+            for (var i = 0; i < Checkboxes().Count; i++)
             {
-                await cbx.ChangeAsync(true);
+                await Checkboxes()[i].ChangeAsync(true);
             }
 
             table.SelectedItems.Count.Should().Be(3);
 
-            foreach (var cbx in checkboxes)
+            for (var i = 0; i < Checkboxes().Count; i++)
             {
-                await cbx.ChangeAsync(false);
+                await Checkboxes()[i].ChangeAsync(false);
             }
             table.SelectedItems.Count.Should().Be(0);
         }
@@ -682,12 +678,12 @@ namespace MudBlazor.UnitTests.Components
         public async Task TableMultiSelection_IgnoreCheckbox_RowClick()
         {
             var comp = Context.Render<TableMultiSelection_IgnoreCheckbox_RowClickTest>();
-            var rows = comp.FindComponent<MudTable<int>>().FindAll("tr").ToArray();
             var table = comp.FindComponent<MudTable<int>>().Instance;
+            IReadOnlyList<IElement> Rows() => comp.FindComponent<MudTable<int>>().FindAll("tr");
 
-            foreach (var row in rows)
+            for (var i = 0; i < Rows().Count; i++)
             {
-                await row.ClickAsync();
+                await Rows()[i].ClickAsync();
             }
             table.SelectedItems.Count.Should().Be(0);
         }
@@ -1014,11 +1010,17 @@ namespace MudBlazor.UnitTests.Components
             // select elements needed for the test
             var tableComponent = comp.FindComponent<MudTable<TableGroupingTest.RacingCar>>();
             var table = tableComponent.Instance;
-            var rows = tableComponent.FindAll("tr").ToArray();
             var headerAndFooterCheckboxes = comp.FindComponents<MudCheckBox<bool?>>().Select(x => x.Instance).ToArray();
             var dataCheckboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
-            foreach (var row in rows.Where(el => el.ClassName.Contains("row-click-test"))) // simulate selection on row click, excluding headers and footer
-                await row.ClickAsync();
+            IReadOnlyList<IElement> Rows() => tableComponent.FindAll("tr");
+            for (var i = 0; i < Rows().Count; i++)
+            {
+                var row = Rows()[i];
+                if (row.ClassName.Contains("row-click-test")) // simulate selection on row click, excluding headers and footer
+                {
+                    await row.ClickAsync();
+                }
+            }
             // check result
             headerAndFooterCheckboxes.Sum(x => x.Disabled ? 0 : 1).Should().Be(0); // No checkbox should be enabled on header, group headers and footer
             dataCheckboxes.Sum(x => x.Disabled ? 1 : 0).Should().Be(comp.Instance.Items.Count()); // No checkbox should be enabled on rows
@@ -1082,10 +1084,10 @@ namespace MudBlazor.UnitTests.Components
             var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
 
             // Skip first two inputs (date filters)
-            var inputs = comp.FindAll("input").Skip(3);
-            foreach (var input in inputs)
+            IReadOnlyList<IElement> Inputs() => comp.FindAll("input");
+            for (var i = 3; i < Inputs().Count; i++)
             {
-                await input.ChangeAsync(true);
+                await Inputs()[i].ChangeAsync(true);
             }
             table.SelectedItems.Count.Should().Be(10);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }");
@@ -1131,10 +1133,10 @@ namespace MudBlazor.UnitTests.Components
             var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
 
             // Skip first two inputs (date filters)
-            var inputs = comp.FindAll("input").Skip(3);
-            foreach (var input in inputs)
+            IReadOnlyList<IElement> Inputs() => comp.FindAll("input");
+            for (var i = 3; i < Inputs().Count; i++)
             {
-                await input.ChangeAsync(true);
+                await Inputs()[i].ChangeAsync(true);
             }
             table.SelectedItems.Count.Should().Be(10);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }");
@@ -1147,7 +1149,7 @@ namespace MudBlazor.UnitTests.Components
             checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
 
             // Find checkboxes, and skip date filter and table header checkbox
-            inputs = comp.FindAll("input").Skip(3);
+            var inputs = comp.FindAll("input").Skip(3);
             inputs.Count().Should().Be(5); // one checkbox per row + one for the header + two date filters
             checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(2);
             // Selection should remain intact
@@ -3074,4 +3076,3 @@ namespace MudBlazor.UnitTests.Components
 
     }
 }
-


### PR DESCRIPTION
### Motivation
- Prevent flaky bUnit tests caused by caching DOM nodes returned from `FindAll(...).ToArray()` or long-lived helpers that become stale after interactions.
- Bring tests into compliance with project testing guidance to re-query the DOM after UI updates.
- Address inline review feedback to avoid creating a helper method when a query is only used once.

### Description
- Replaced single-use cached queries with inline calls such as `comp.FindAll("..." )[index]` in `src/MudBlazor.UnitTests/Components/FormTests.cs`, `RadioTests.cs`, `SelectTests.cs`, and `TableTests.cs` to ensure elements are resolved at interaction time.
- Kept on-demand local helpers like `IReadOnlyList<IElement> Items() => comp.FindAll(...)` only where the list is used multiple times across interactions.
- Removed `.ToArray()` caching in many tests and added `using AngleSharp.Dom` where `IElement` types are referenced.

### Testing
- Attempted to run the required formatter with `dotnet format ... --include <files>` but it failed because `dotnet` is not available in the current environment. 
- No automated `dotnet test` runs were executed here due to missing .NET tooling. 
- Changes were validated via static inspection and search-based checks to ensure all single-use cached queries were inlined where applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783b86d9e4832886478b694a5e5218)