### PR TITLE
Use tj-actions/changed-files to simplify dotnet format step

### DIFF
--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Cache NuGet packages
         uses: actions/cache@v5

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -46,10 +46,8 @@ jobs:
             src/**
 
       - name: dotnet format
-        working-directory: src
         run: |
           if [ "${{ steps.changed-files.outputs.any_changed }}" != "true" ]; then
-            echo "No files changed under src/, skipping dotnet format."
             exit 0
           fi
           dotnet format --no-restore --verify-no-changes --include ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -16,9 +16,12 @@ env:
 
 jobs:
   format-check:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -37,9 +40,21 @@ jobs:
 
       - uses: xt0rted/dotnet-format-problem-matcher@v1
 
+      - name: Determine changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            src/**
+
       - name: dotnet format
         working-directory: src
-        run: dotnet format --no-restore --verify-no-changes
+        run: |
+          if [ "${{ steps.changed-files.outputs.any_changed }}" != "true" ]; then
+            echo "No files changed under src/, skipping dotnet format."
+            exit 0
+          fi
+          dotnet format --no-restore --verify-no-changes --include ${{ steps.changed-files.outputs.all_changed_files }}
 
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -50,7 +50,7 @@ jobs:
           if [ "${{ steps.changed-files.outputs.any_changed }}" != "true" ]; then
             exit 0
           fi
-          dotnet format --no-restore --verify-no-changes --include ${{ steps.changed-files.outputs.all_changed_files }}
+          dotnet format src --no-restore --verify-no-changes --include ${{ steps.changed-files.outputs.all_changed_files }}
 
   build-test:
     runs-on: ubuntu-latest

--- a/src/MudBlazor.Docs.WasmHost/Controllers/AmericanStatesController.cs
+++ b/src/MudBlazor.Docs.WasmHost/Controllers/AmericanStatesController.cs
@@ -25,7 +25,7 @@ public class AmericanStatesController : ControllerBase
         var input = (search ?? string.Empty).Trim().ToLower();
         var states = AmericanStates.GetStates();
 
-        List<string> result = new();
+        List<string> result = new();   
         foreach (var item in states)
         {
             if (string.IsNullOrEmpty(input) || item.Contains(input, StringComparison.InvariantCultureIgnoreCase))

--- a/src/MudBlazor.Docs.WasmHost/Controllers/AmericanStatesController.cs
+++ b/src/MudBlazor.Docs.WasmHost/Controllers/AmericanStatesController.cs
@@ -13,6 +13,7 @@ namespace MudBlazor.Docs.WasmHost.Controllers;
 public class AmericanStatesController : ControllerBase
 {
     [HttpGet("{search}")]
+    
     public IEnumerable<string> Get(string search) => AmericanStates.GetStates(search);
 
     [HttpGet]
@@ -22,8 +23,8 @@ public class AmericanStatesController : ControllerBase
     [OperationCancelledExceptionFilter]
     public async Task<IActionResult> SearchWithDelay(CancellationToken cancellationToken, [FromRoute(Name = "input")] string search = "")
     {
-        var input = (search ?? string.Empty).Trim().ToLower();
-        var states = AmericanStates.GetStates();
+          var input = (search ?? string.Empty).Trim().ToLower();
+        var states =  AmericanStates.GetStates();
 
         List<string> result = new();   
         foreach (var item in states)

--- a/src/MudBlazor.Docs.WasmHost/Controllers/AmericanStatesController.cs
+++ b/src/MudBlazor.Docs.WasmHost/Controllers/AmericanStatesController.cs
@@ -13,7 +13,6 @@ namespace MudBlazor.Docs.WasmHost.Controllers;
 public class AmericanStatesController : ControllerBase
 {
     [HttpGet("{search}")]
-    
     public IEnumerable<string> Get(string search) => AmericanStates.GetStates(search);
 
     [HttpGet]
@@ -23,10 +22,10 @@ public class AmericanStatesController : ControllerBase
     [OperationCancelledExceptionFilter]
     public async Task<IActionResult> SearchWithDelay(CancellationToken cancellationToken, [FromRoute(Name = "input")] string search = "")
     {
-          var input = (search ?? string.Empty).Trim().ToLower();
-        var states =  AmericanStates.GetStates();
+        var input = (search ?? string.Empty).Trim().ToLower();
+        var states = AmericanStates.GetStates();
 
-        List<string> result = new();   
+        List<string> result = new();
         foreach (var item in states)
         {
             if (string.IsNullOrEmpty(input) || item.Contains(input, StringComparison.InvariantCultureIgnoreCase))


### PR DESCRIPTION
### Motivation
- Replace a custom, hard-to-read `git` fetch/diff snippet with a well-maintained action to improve readability and maintainability of the format check. 
- Ensure the format check runs only for pull requests and only when `src/**` files changed to avoid unnecessary CI work. 

### Description
- Gate the `format-check` job to pull requests with `if: ${{ github.event_name == 'pull_request' }}`. 
- Use `actions/checkout@v6` with `fetch-depth: 0` to ensure the changed-files action can compare commits. 
- Add `tj-actions/changed-files@v46` to compute `src/**` changes and use its `any_changed` and `all_changed_files` outputs. 
- Change the `dotnet format` step to skip when no `src/` files changed and otherwise call `dotnet format --no-restore --verify-no-changes --include ${{ steps.changed-files.outputs.all_changed_files }}` while keeping the existing problem matcher. 

### Testing
- No automated tests were executed because this is a CI workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697848923fdc8328998071cb129ac11a)