### PR TITLE
Split docs unit tests into a dedicated CI job

### DIFF
--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -41,7 +41,155 @@ jobs:
         working-directory: src
         run: dotnet format --no-restore --verify-no-changes
 
-  build-test:
+  build-core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+          path: ${{ env.NUGET_PACKAGES }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.x
+            9.x
+            8.x
+
+      - name: Restore dependencies
+        working-directory: src
+        run: dotnet restore
+
+      - name: Build MudBlazor core
+        working-directory: src
+        run: dotnet build MudBlazor/MudBlazor.csproj -c Release --no-restore
+
+  build-analyzers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+          path: ${{ env.NUGET_PACKAGES }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.x
+            9.x
+            8.x
+
+      - name: Restore dependencies
+        working-directory: src
+        run: dotnet restore
+
+      - name: Build analyzers
+        working-directory: src
+        run: dotnet build MudBlazor.Analyzers/MudBlazor.Analyzers.csproj -c Release --no-restore
+
+      - name: Build analyzer code fixes
+        working-directory: src
+        run: dotnet build MudBlazor.Analyzers.CodeFixes/MudBlazor.Analyzers.CodeFixes.csproj -c Release --no-restore
+
+      - name: Build analyzer test components
+        working-directory: src
+        run: dotnet build MudBlazor.Analyzers.TestComponents/MudBlazor.Analyzers.TestComponents.csproj -c Release --no-restore
+
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+          path: ${{ env.NUGET_PACKAGES }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.x
+            9.x
+            8.x
+
+      - name: Restore dependencies
+        working-directory: src
+        run: dotnet restore
+
+      - name: Build docs compiler
+        working-directory: src
+        run: dotnet build MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj -c Release --no-restore
+
+      - name: Build docs site
+        working-directory: src
+        run: dotnet build MudBlazor.Docs/MudBlazor.Docs.csproj -c Release --no-restore
+
+      - name: Build docs wasm
+        working-directory: src
+        run: dotnet build MudBlazor.Docs.Wasm/MudBlazor.Docs.Wasm.csproj -c Release --no-restore
+
+      - name: Build docs wasm host
+        working-directory: src
+        run: dotnet build MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj -c Release --no-restore
+
+      - name: Build docs server
+        working-directory: src
+        run: dotnet build MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj -c Release --no-restore
+
+      - name: Build examples data
+        working-directory: src
+        run: dotnet build MudBlazor.Examples.Data/MudBlazor.Examples.Data.csproj -c Release --no-restore
+
+  build-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+          path: ${{ env.NUGET_PACKAGES }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.x
+            9.x
+            8.x
+
+      - name: Restore dependencies
+        working-directory: src
+        run: dotnet restore
+
+      - name: Build docs tests generator
+        working-directory: src
+        run: dotnet build MudBlazor.UnitTests.Docs.Generator/MudBlazor.UnitTests.Docs.Generator.csproj -c Release --no-restore
+
+      - name: Build unit tests shared
+        working-directory: src
+        run: dotnet build MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj -c Release --no-restore
+
+      - name: Build unit tests viewer
+        working-directory: src
+        run: dotnet build MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj -c Release --no-restore
+
+      - name: Build benchmarks
+        working-directory: src
+        run: dotnet build MudBlazor.Benchmarks/MudBlazor.Benchmarks.csproj -c Release --no-restore
+
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -65,13 +213,13 @@ jobs:
         working-directory: src
         run: dotnet restore
 
-      - name: Build solution
+      - name: Build MudBlazor unit tests
         working-directory: src
-        run: dotnet build -c Release --no-restore
+        run: dotnet build MudBlazor.UnitTests/MudBlazor.UnitTests.csproj -c Release --no-restore
 
-      - name: Test solution
+      - name: Test MudBlazor unit tests
         working-directory: src
-        run: dotnet test -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
+        run: dotnet test MudBlazor.UnitTests/MudBlazor.UnitTests.csproj -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
 
       - name: Publish coverage
         uses: codecov/codecov-action@v5
@@ -85,3 +233,48 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
           files: src/junit.xml
+
+  docs-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+          path: ${{ env.NUGET_PACKAGES }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          # We need all runtimes for the tests
+          dotnet-version: |
+            10.x
+            9.x
+            8.x
+
+      - name: Restore dependencies
+        working-directory: src
+        run: dotnet restore
+
+      - name: Build MudBlazor docs unit tests
+        working-directory: src
+        run: dotnet build MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj -c Release --no-restore
+
+      - name: Test MudBlazor docs unit tests
+        working-directory: src
+        run: dotnet test MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/docs-' --logger "junit;LogFilePath=junit-docs.xml"
+
+      - name: Publish docs coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload docs test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          files: src/junit-docs.xml


### PR DESCRIPTION
### Motivation
- Prevent the main `unit-tests` job from rebuilding docs projects to improve parallelization and reduce CI build time.
- Target specific projects per job to keep builds focused and cache-friendly.

### Description
- Removed building and testing of `MudBlazor.UnitTests.Docs` from the `unit-tests` job and narrowed `unit-tests` to build and test only `MudBlazor.UnitTests` with its own coverage and `junit.xml` upload.
- Added a new `docs-tests` job that restores, builds, and runs `MudBlazor.UnitTests.Docs` and uploads its own coverage and `junit-docs.xml` to Codecov.
- Introduced separate jobs `build-core`, `build-analyzers`, `build-docs`, and `build-tools` that each restore and build the intended project(s) instead of a monolithic solution build.
- Updated ` .github/workflows/build-test-mudblazor.yml` to reflect the job splits and to upload test results from each job individually.

### Testing
- No automated CI or unit tests were executed because this change only modifies the GitHub Actions workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697841f3ef8c8328bbcde62791b638d5)