### PR TITLE
Allow mini drawer to switch to temporary variant on small screens

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -205,6 +205,23 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task MiniOnSmallScreens_BehavesLikeTemporaryDrawer()
+        {
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini));
+
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+        }
+
+        [Test]
         public async Task ResponsiveClosed_Open_CheckOpened_Close_CheckClosedAsync()
         {
             _ = AddBrowserViewportService();

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -43,7 +43,9 @@ namespace MudBlazor
                 .WithChangeHandler(OnRightToLeftParameterChanged);
         }
 
-        private bool OverlayVisible => _openState.Value && Overlay && (Variant == DrawerVariant.Temporary || (IsBelowCurrentBreakpoint() && IsResponsiveOrMini()));
+        private DrawerVariant EffectiveVariant => Variant == DrawerVariant.Mini && IsBelowCurrentBreakpoint() ? DrawerVariant.Temporary : Variant;
+
+        private bool OverlayVisible => _openState.Value && Overlay && (EffectiveVariant == DrawerVariant.Temporary || (IsBelowCurrentBreakpoint() && IsResponsiveOrMini()));
 
         protected string Classname =>
             new CssBuilder("mud-drawer")
@@ -56,7 +58,7 @@ namespace MudBlazor
                 .AddClass($"mud-drawer-clipped-{ClipMode.ToStringFast(true)}")
                 .AddClass($"mud-theme-{Color.ToStringFast(true)}", Color != Color.Default)
                 .AddClass($"mud-elevation-{Elevation}")
-                .AddClass($"mud-drawer-{Variant.ToStringFast(true)}")
+                .AddClass($"mud-drawer-{EffectiveVariant.ToStringFast(true)}")
                 .AddClass(Class)
                 .Build();
 
@@ -64,7 +66,7 @@ namespace MudBlazor
             new CssBuilder("mud-drawer-overlay mud-overlay-drawer")
                 .AddClass($"mud-drawer-pos-{GetPosition()}")
                 .AddClass($"mud-drawer-overlay--open", _openState.Value)
-                .AddClass($"mud-drawer-overlay-{Variant.ToStringFast(true)}")
+                .AddClass($"mud-drawer-overlay-{EffectiveVariant.ToStringFast(true)}")
                 .AddClass($"mud-drawer-overlay-{Breakpoint.ToStringFast(true)}")
                 .AddClass($"mud-drawer-overlay--initial", _initial)
                 .AddClass($"mud-skip-overlay-positioning") // popovers try to position the overlay by zindex, this skips that behavior
@@ -415,6 +417,8 @@ namespace MudBlazor
 
         internal bool IsFixed => Fixed && DrawerContainer is MudLayout;
 
+        internal DrawerVariant GetEffectiveVariant() => EffectiveVariant;
+
         private async Task OnPointerEnterAsync()
         {
             if (Variant == DrawerVariant.Mini && !_openState.Value && OpenMiniOnHover)
@@ -435,7 +439,7 @@ namespace MudBlazor
 
         async Task INavigationEventReceiver.OnNavigation()
         {
-            if (Variant == DrawerVariant.Temporary ||
+            if (EffectiveVariant == DrawerVariant.Temporary ||
                 (Variant == DrawerVariant.Responsive && await BrowserViewportService.GetCurrentBreakpointAsync() < Breakpoint))
             {
                 await _openState.SetValueAsync(false);

--- a/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
@@ -68,8 +68,9 @@ namespace MudBlazor
                 return string.Empty;
             }
 
-            var className = $"mud-drawer-{(drawer.GetState<bool>(nameof(MudDrawer.Open)) ? "open" : "close")}-{drawer.Variant.ToStringFast(true)}";
-            if (drawer.Variant is DrawerVariant.Responsive or DrawerVariant.Mini)
+            var effectiveVariant = drawer.GetEffectiveVariant();
+            var className = $"mud-drawer-{(drawer.GetState<bool>(nameof(MudDrawer.Open)) ? "open" : "close")}-{effectiveVariant.ToStringFast(true)}";
+            if (effectiveVariant is DrawerVariant.Responsive or DrawerVariant.Mini)
             {
                 className += $"-{drawer.Breakpoint.ToStringFast(true)}";
             }


### PR DESCRIPTION
### Motivation
- Mini drawers remaining visible on small/mobile screens wastes space and is uncomfortable for users, so they should behave like temporary drawers on narrow viewports by default.
- The responsive variant already transitions between persistent and temporary based on breakpoint, and mini should follow the same "just works" behavior without requiring new API usage.

### Description
- Add an `EffectiveVariant` computed property to `MudDrawer` that returns `Temporary` when `Variant == DrawerVariant.Mini` and the viewport is below the configured breakpoint. (`src/MudBlazor/Components/Drawer/MudDrawer.razor.cs`)
- Use the effective variant for drawer and overlay CSS class generation and for navigation auto-close logic so mini drawers open over content and hide completely when closed on small screens. (`src/MudBlazor/Components/Drawer/MudDrawer.razor.cs`)
- Expose a `GetEffectiveVariant()` helper on `MudDrawer` and update `MudDrawerContainer` class generation to use the drawer’s effective variant to avoid applying mini layout spacing classes when the drawer is acting as temporary. (`src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs`)
- Add a unit test `MiniOnSmallScreens_BehavesLikeTemporaryDrawer` to assert that a mini drawer on an `Xs` viewport renders with temporary classes and an overlay when opened and hides when closed. (`src/MudBlazor.UnitTests/Components/DrawerTest.cs`)

### Testing
- A new unit test `MiniOnSmallScreens_BehavesLikeTemporaryDrawer` was added to `src/MudBlazor.UnitTests/Components/DrawerTest.cs` and should be run as part of the drawer test group. 
- Automated test execution could not be performed in this environment because the `dotnet` CLI was not available (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a85ff17483289447f6dbf1036481)