### PR TITLE
Update AutoTriage workflows to v4

### DIFF
--- a/.github/workflows/autotriage-backlog.yml
+++ b/.github/workflows/autotriage-backlog.yml
@@ -19,11 +19,6 @@ on:
         type: number
         required: false
         default: 20
-      context-caching:
-        description: "Enable context caching"
-        type: boolean
-        required: false
-        default: true
       extended:
         description: "Enable extended analysis"
         type: boolean
@@ -77,7 +72,6 @@ jobs:
           prompt-path: .github/AutoTriage.prompt
           dry-run: ${{ github.event_name != 'schedule' && inputs['dry-run'] }}
           max-fast-runs: ${{ github.event_name == 'workflow_dispatch' && inputs['max-fast-runs'] || 20 }}
-          context-caching: ${{ github.event_name == 'workflow_dispatch' && inputs['context-caching'] || true }}
           extended: ${{ github.event_name == 'workflow_dispatch' && inputs['extended'] || true }}
           model-fast: ${{ github.event_name == 'workflow_dispatch' && inputs['model-fast'] || 'gemini-3.1-flash-lite' }}
           model-pro: ${{ github.event_name == 'workflow_dispatch' && inputs['model-pro'] || 'gemini-3.5-flash' }}

--- a/.github/workflows/autotriage-backlog.yml
+++ b/.github/workflows/autotriage-backlog.yml
@@ -38,7 +38,7 @@ on:
         description: "Pro model"
         type: string
         required: false
-        default: gemini-3-flash-preview
+        default: gemini-3.5-flash
 
 permissions:
   contents: read
@@ -71,7 +71,7 @@ jobs:
             ${{ runner.os }}-triage-db-
 
       - name: AutoTriage - triage backlog
-        uses: danielchalmers/AutoTriage@v3
+        uses: danielchalmers/AutoTriage@v4
         with:
           issues: ${{ github.event.inputs.issues }}
           prompt-path: .github/AutoTriage.prompt
@@ -80,7 +80,7 @@ jobs:
           context-caching: ${{ github.event_name == 'workflow_dispatch' && inputs['context-caching'] || true }}
           extended: ${{ github.event_name == 'workflow_dispatch' && inputs['extended'] || true }}
           model-fast: ${{ github.event_name == 'workflow_dispatch' && inputs['model-fast'] || 'gemini-3.1-flash-lite' }}
-          model-pro: ${{ github.event_name == 'workflow_dispatch' && inputs['model-pro'] || 'gemini-3-flash-preview' }}
+          model-pro: ${{ github.event_name == 'workflow_dispatch' && inputs['model-pro'] || 'gemini-3.5-flash' }}
           db-path: triage-db.json
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/autotriage-issues.yml
+++ b/.github/workflows/autotriage-issues.yml
@@ -35,12 +35,12 @@ jobs:
             ${{ runner.os }}-triage-db-
 
       - name: AutoTriage - triage issue
-        uses: danielchalmers/AutoTriage@v3
+        uses: danielchalmers/AutoTriage@v4
         with:
           issues: ${{ github.event.issue.number }}
           prompt-path: .github/AutoTriage.prompt
           model-fast: "" # skip fast pass
-          model-pro: gemini-3.1-pro-preview
+          model-pro: 'gemini-3.5-flash'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/autotriage-prs.yml
+++ b/.github/workflows/autotriage-prs.yml
@@ -35,12 +35,12 @@ jobs:
             ${{ runner.os }}-triage-db-
 
       - name: AutoTriage - triage pull request
-        uses: danielchalmers/AutoTriage@v3
+        uses: danielchalmers/AutoTriage@v4
         with:
           issues: ${{ github.event.pull_request.number }}
           prompt-path: .github/AutoTriage.prompt
           model-fast: "" # skip fast pass
-          model-pro: gemini-3.1-pro-preview
+          model-pro: 'gemini-3.5-flash'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary
- update AutoTriage workflow actions from v3 to v4
- switch pro model defaults/usages to gemini-3.5-flash

## Testing
- Not run; GitHub workflow-only change.