### PR TITLE
Build: Add manual PR snapshot nuget workflow

### DIFF
--- a/.github/workflows/deploy-mudblazor-pr-snapshot.yml
+++ b/.github/workflows/deploy-mudblazor-pr-snapshot.yml
@@ -1,0 +1,125 @@
+name: deploy-mudblazor-pr-snapshot
+
+# Manually builds a snapshot nuget package from a PR's head commit and
+# publishes it to GitHub Packages so the PR can be tested in real projects.
+# Note: this builds untrusted PR code, but dispatching requires write access.
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to build a snapshot package from"
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+env:
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
+jobs:
+  get-snapshot-version:
+    runs-on: ubuntu-latest
+    # Only run on the main repository, not forks
+    if: github.repository == 'MudBlazor/MudBlazor'
+    permissions:
+      contents: read
+    outputs:
+      VERSION: ${{ steps.get-version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Fetch all history for tags
+
+      - name: Get latest tag and generate snapshot version
+        id: get-version
+        run: |
+          # Get the latest tag
+          LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+          # If no tag found, use default version
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.1"
+          fi
+
+          # Remove 'v' prefix
+          VERSION="${LATEST_TAG#v}"
+
+          # Append PR snapshot identifier with run number
+          SNAPSHOT_VERSION="${VERSION}-pr.${{ inputs.pr_number }}.${GITHUB_RUN_NUMBER}"
+
+          echo "Latest tag: $LATEST_TAG"
+          echo "Snapshot version: $SNAPSHOT_VERSION"
+          echo "VERSION=$SNAPSHOT_VERSION" >> $GITHUB_OUTPUT
+
+  deploy-snapshot:
+    runs-on: ubuntu-latest
+    needs: get-snapshot-version
+    # Only run on the main repository, not forks
+    if: github.repository == 'MudBlazor/MudBlazor'
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ inputs.pr_number }}/head
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+          path: ${{ env.NUGET_PACKAGES }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+
+      - name: Restore dependencies
+        working-directory: src/MudBlazor
+        run: dotnet restore
+
+      - name: Pack nuget package
+        working-directory: ./src/MudBlazor
+        run: dotnet pack -c Release --no-restore --output nupkgs /p:Version=${{ needs.get-snapshot-version.outputs.VERSION }}
+
+      - name: Check package contains css
+        shell: pwsh
+        run: ./tools/CheckPackageContainsStaticAssets.ps1 ./src/MudBlazor/nupkgs MudBlazor.min.css
+
+      - name: Check package contains js
+        shell: pwsh
+        run: ./tools/CheckPackageContainsStaticAssets.ps1 ./src/MudBlazor/nupkgs MudBlazor.min.js
+
+      - name: Publish snapshot package to GitHub Packages
+        working-directory: ./src/MudBlazor
+        run: |
+          dotnet nuget push nupkgs/*.nupkg \
+            --api-key ${{ secrets.GITHUB_TOKEN }} \
+            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            --skip-duplicate
+
+      - name: Upload snapshot package as artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: mudblazor-pr-${{ inputs.pr_number }}-${{ needs.get-snapshot-version.outputs.VERSION }}
+          path: ./src/MudBlazor/nupkgs/*.nupkg
+          retention-days: 30
+
+      - name: Write summary
+        run: |
+          BUILT_SHA=$(git rev-parse HEAD)
+          {
+            echo "## PR snapshot package"
+            echo ""
+            echo "- **PR:** [#${{ inputs.pr_number }}](${{ github.server_url }}/${{ github.repository }}/pull/${{ inputs.pr_number }})"
+            echo "- **Commit:** \`$BUILT_SHA\`"
+            echo "- **Version:** \`${{ needs.get-snapshot-version.outputs.VERSION }}\`"
+            echo ""
+            echo "Install from GitHub Packages (requires a PAT with \`read:packages\`):"
+            echo ""
+            echo '```sh'
+            echo "dotnet nuget add source \"https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json\" --name mudblazor-gh --username YOUR_GITHUB_USERNAME --password YOUR_PAT --store-password-in-clear-text"
+            echo "dotnet add package MudBlazor --version ${{ needs.get-snapshot-version.outputs.VERSION }}"
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Adds `deploy-mudblazor-pr-snapshot.yml`, a manually-dispatched workflow that builds a snapshot nuget package from a specific PR and publishes it to GitHub Packages, so a PR can be tested in real projects before it merges.

**How it works:**
- Triggered from the Actions tab (`workflow_dispatch`) with a required PR number input. Dispatching requires write access, which is what gates building untrusted PR code.
- Versioning follows the nightly workflow: latest `v*` tag + `-pr.<number>.<run_number>` (e.g. `8.9.0-pr.13288.1`), so snapshots are sortable per PR and clearly prerelease.
- Builds from `refs/pull/<number>/head` (the PR''s actual commits, not the merge ref), so it works even if the PR conflicts with dev.
- Reuses the nightly deploy steps: nuget cache, restore, `dotnet pack`, the css/js static-asset checks, push to GitHub Packages with `--skip-duplicate`, and a 30-day `.nupkg` artifact.
- Writes a job summary with the built commit SHA, version, and copy-pasteable install commands (GitHub Packages requires a PAT with `read:packages` to consume).

**Notes for reviewers:**
- Concurrency is grouped per PR number: re-dispatching for the same PR cancels the in-flight run; different PRs run in parallel.
- Both jobs are gated to `github.repository == ''MudBlazor/MudBlazor''` like the nightly workflow.

**Checklist:**
- [x] I''ve read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I''ve added or updated relevant unit tests (N/A — CI workflow only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)