### PR TITLE
MudSelect: Hide clear button when value equals default(T) (#13372)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -992,6 +992,54 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.ClearButtonClicked.Should().BeTrue();
         }
 
+        [Test]
+        public async Task SelectClearable_NonNullableEnum_HiddenWhileValueIsDefault()
+        {
+            // #13372: a non-nullable value type's default (here the zero enum member) is the cleared state,
+            // so the clear button must stay hidden until a different value is selected.
+            var comp = Context.Render<MudSelect<MyEnum>>(p => p
+                .Add(x => x.Clearable, true)
+                .Add(x => x.Value, MyEnum.First));
+
+            comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
+
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Value, MyEnum.Second));
+            comp.FindAll(".mud-input-clear-button").Should().ContainSingle();
+
+            // Returning to the default hides it again (clearing default would be a no-op).
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Value, MyEnum.First));
+            comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task SelectClearable_NonNullableInt_HiddenWhileValueIsDefault()
+        {
+            // #13372: default(int) is the cleared state, so no clear button until a non-zero value is selected.
+            var comp = Context.Render<MudSelect<int>>(p => p
+                .Add(x => x.Clearable, true)
+                .Add(x => x.Value, 0));
+
+            comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
+
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Value, 2));
+            comp.FindAll(".mud-input-clear-button").Should().ContainSingle();
+        }
+
+        [Test]
+        public async Task SelectClearable_NullableValueType_ShownForZero()
+        {
+            // #13372: for a nullable value type the default is null, so a real zero selection is distinct from
+            // cleared and stays clearable (clearing takes it from 0 to null).
+            var comp = Context.Render<MudSelect<int?>>(p => p
+                .Add(x => x.Clearable, true)
+                .Add(x => x.Value, (int?)null));
+
+            comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
+
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Value, (int?)0));
+            comp.FindAll(".mud-input-clear-button").Should().ContainSingle();
+        }
+
         /// <summary>
         /// Reselect an already selected value should not call SelectedValuesChanged event.
         /// </summary>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -44,7 +44,7 @@
                           IconSize="@IconSize"
                           AdornmentAriaLabel="@AdornmentAriaLabel"
                           OnAdornmentClick="@OnAdornmentClick"
-                          Clearable="@(Clearable && !GetReadOnlyState())"
+                          Clearable="@(Clearable && !GetReadOnlyState() && HasClearableValue())"
                           ClearIcon="@ClearIcon"
                           OnClearButtonClick="@(async (e) => await SelectClearButtonClickHandlerAsync(e))"
                           @attributes="GetInputUserAttributes()"

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -499,6 +499,26 @@ namespace MudBlazor
         protected bool IsValueInList => _context.TryGetShadowItemByValue(ReadValue, out _);
 
         /// <summary>
+        /// Whether the clear button has something to clear.
+        /// </summary>
+        /// <remarks>
+        /// Clearing resets the selection to <c>default(T)</c>, so there is nothing to clear while the
+        /// selection already equals it. For a non-nullable value type the default (e.g. <c>0</c> or the
+        /// zero enum member) is that cleared state, so the button stays hidden until a different value is
+        /// selected. For nullable and reference types the default is <c>null</c>, so any non-null selection
+        /// (including a value type's zero) is clearable. Uses the same equality as the clear operation (#13372).
+        /// </remarks>
+        private bool HasClearableValue()
+        {
+            if (MultiSelection)
+            {
+                return _selectedValues.Count > 0;
+            }
+
+            return !EqualityComparer<T?>.Default.Equals(ReadValue, default);
+        }
+
+        /// <summary>
         /// Builds fallback accessibility attributes for the focused select trigger.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Fixes #13372.

### Problem
`MudSelect<T>` with `Clearable` showed the clear (×) button even when the value was `default(T)` for a non-nullable value type (`int` = 0, the zero enum member). Clicking it reset `Value` to `default(T)` — a no-op for a non-nullable struct — so nothing changed and the button reappeared on the next render. Nullable and reference types were already correct.

### Cause
The clear button is rendered by the inner `MudInput<string>`, whose `ShowClearButton()` only checks that the display text is non-empty. A non-nullable value type's default always converts to non-empty text (`0`, `Spring`), so the button always showed.

### Fix
Gate the inner input's `Clearable` on a new `HasClearableValue()`:
- Single selection: value must differ from `default(T)`.
- `MultiSelection`: at least one value selected.

It uses `EqualityComparer<T?>.Default` — the same equality the clear operation uses to decide whether the value changed — so the button appears exactly when clearing would change the value. `default` resolves to `default(T)` (`0`/`null`) because `MudBaseInput<T>` has no `struct` constraint. Nullable/reference types are unaffected: their default is `null`, so a value type's zero (e.g. `int?` = 0) remains clearable.

### Behavior
| Case | Before | After |
| --- | --- | --- |
| `int` = 0 (default) | × shown | hidden |
| enum = zero member (default) | × shown | hidden |
| `int` = 2 (non-default) | × shown | × shown |
| `int?` = null | hidden | hidden |
| `int?` = 0 (≠ null) | × shown | × shown |
| `string` = null | hidden | hidden |

Before/after (harness at default values — non-nullable `int`/enum on top):

<!-- before/after screenshots -->

### Tests
- Added `SelectClearable_NonNullableEnum_HiddenWhileValueIsDefault`, `SelectClearable_NonNullableInt_HiddenWhileValueIsDefault`, `SelectClearable_NullableValueType_ShownForZero`.
- Verified interactively in a Blazor Server harness; full `SelectTests` fixture green.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
