### PR TITLE
MudDrawer: Apply Width, MiniWidth and Height changes without a render delay

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerContainerSizeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerContainerSizeTest.razor
@@ -1,0 +1,20 @@
+﻿<MudDrawerContainer id="drawer-container">
+    <MudDrawer id="drawer" Open="true" Fixed="false" Variant="@Variant" Anchor="@Anchor" Width="@Width" MiniWidth="@MiniWidth" Height="@Height" />
+</MudDrawerContainer>
+
+@code {
+    [Parameter]
+    public DrawerVariant Variant { get; set; } = DrawerVariant.Persistent;
+
+    [Parameter]
+    public Anchor Anchor { get; set; } = Anchor.Start;
+
+    [Parameter]
+    public string? Width { get; set; }
+
+    [Parameter]
+    public string? MiniWidth { get; set; }
+
+    [Parameter]
+    public string? Height { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerLayoutSizeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerLayoutSizeTest.razor
@@ -1,0 +1,8 @@
+﻿<MudLayout id="drawer-layout">
+    <MudDrawer id="drawer" Open="true" Variant="DrawerVariant.Persistent" Width="@Width" />
+</MudLayout>
+
+@code {
+    [Parameter]
+    public string? Width { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -817,6 +817,82 @@ namespace MudBlazor.UnitTests.Components
             styles.Single(a => a.Name == "--mud-drawer-height").Value.Should().Be(drawerHeight);
         }
 
+        [Test]
+        [TestCase(Anchor.Start, "--mud-drawer-width-left")]
+        [TestCase(Anchor.End, "--mud-drawer-width-right")]
+        public async Task DrawerContainer_WidthChanged_UpdatesContainerVariableAsync(Anchor anchor, string variable)
+        {
+            _ = AddBrowserViewportService();
+            var comp = Context.Render<DrawerContainerSizeTest>(parameters => parameters
+                .Add(x => x.Anchor, anchor)
+                .Add(x => x.Width, "150px"));
+
+            comp.Find("#drawer-container").GetStyle().Single(a => a.Name == variable).Value.Should().Be("150px");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Width, "250px"));
+
+            comp.Find("#drawer-container").GetStyle().Single(a => a.Name == variable).Value.Should().Be("250px");
+        }
+
+        [Test]
+        public async Task DrawerContainer_MiniWidthChanged_UpdatesContainerVariableAsync()
+        {
+            _ = AddBrowserViewportService();
+            var comp = Context.Render<DrawerContainerSizeTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini)
+                .Add(x => x.MiniWidth, "56px"));
+
+            comp.Find("#drawer-container").GetStyle().Single(a => a.Name == "--mud-drawer-width-mini-left").Value.Should().Be("56px");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.MiniWidth, "72px"));
+
+            comp.Find("#drawer-container").GetStyle().Single(a => a.Name == "--mud-drawer-width-mini-left").Value.Should().Be("72px");
+        }
+
+        [Test]
+        public async Task DrawerContainer_HeightChanged_UpdatesContainerVariableAsync()
+        {
+            _ = AddBrowserViewportService();
+            var comp = Context.Render<DrawerContainerSizeTest>(parameters => parameters
+                .Add(x => x.Anchor, Anchor.Top)
+                .Add(x => x.Height, "150px"));
+
+            comp.Find("#drawer-container").GetStyle().Single(a => a.Name == "--mud-drawer-height-top").Value.Should().Be("150px");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Height, "250px"));
+
+            comp.Find("#drawer-container").GetStyle().Single(a => a.Name == "--mud-drawer-height-top").Value.Should().Be("250px");
+        }
+
+        [Test]
+        public async Task DrawerContainer_WidthChanged_DoesNotRenderRepeatedlyAsync()
+        {
+            _ = AddBrowserViewportService();
+            var comp = Context.Render<DrawerContainerSizeTest>(parameters => parameters
+                .Add(x => x.Width, "150px"));
+            var container = comp.FindComponent<MudDrawerContainer>();
+
+            var changedRenders = new List<int>();
+            foreach (var width in new[] { "250px", "350px", "450px" })
+            {
+                var before = container.RenderCount;
+                await comp.SetParametersAndRenderAsync(parameters => parameters
+                    .Add(x => x.Width, width));
+                changedRenders.Add(container.RenderCount - before);
+            }
+
+            var beforeUnchanged = container.RenderCount;
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Width, "450px"));
+            var unchangedRenders = container.RenderCount - beforeUnchanged;
+
+            changedRenders.Should().AllBeEquivalentTo(changedRenders[0]);
+            unchangedRenders.Should().BeLessThan(changedRenders[0]);
+        }
+
         /// <summary>
         /// Test for issue #3378: Verifies that the mud-drawer--initial class is removed after first interaction.
         /// This class is used to skip the initial CSS transition when the drawer first renders.

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -817,10 +817,13 @@ namespace MudBlazor.UnitTests.Components
             styles.Single(a => a.Name == "--mud-drawer-height").Value.Should().Be(drawerHeight);
         }
 
+        /// <summary>
+        /// Test for issue #6791: Verifies that changing <see cref="MudDrawer.Width"/> updates the container's width variable without a further render.
+        /// </summary>
         [Test]
         [TestCase(Anchor.Start, "--mud-drawer-width-left")]
         [TestCase(Anchor.End, "--mud-drawer-width-right")]
-        public async Task DrawerContainer_WidthChanged_UpdatesContainerVariableAsync(Anchor anchor, string variable)
+        public async Task DrawerContainer_WidthChanged_UpdatesContainerVariable(Anchor anchor, string variable)
         {
             _ = AddBrowserViewportService();
             var comp = Context.Render<DrawerContainerSizeTest>(parameters => parameters
@@ -835,8 +838,11 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("#drawer-container").GetStyle().Single(a => a.Name == variable).Value.Should().Be("250px");
         }
 
+        /// <summary>
+        /// Test for issue #6791: Verifies that changing <see cref="MudDrawer.MiniWidth"/> updates the container's mini width variable without a further render.
+        /// </summary>
         [Test]
-        public async Task DrawerContainer_MiniWidthChanged_UpdatesContainerVariableAsync()
+        public async Task DrawerContainer_MiniWidthChanged_UpdatesContainerVariable()
         {
             _ = AddBrowserViewportService();
             var comp = Context.Render<DrawerContainerSizeTest>(parameters => parameters
@@ -851,8 +857,11 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("#drawer-container").GetStyle().Single(a => a.Name == "--mud-drawer-width-mini-left").Value.Should().Be("72px");
         }
 
+        /// <summary>
+        /// Test for issue #6791: Verifies that changing <see cref="MudDrawer.Height"/> updates the container's height variable without a further render.
+        /// </summary>
         [Test]
-        public async Task DrawerContainer_HeightChanged_UpdatesContainerVariableAsync()
+        public async Task DrawerContainer_HeightChanged_UpdatesContainerVariable()
         {
             _ = AddBrowserViewportService();
             var comp = Context.Render<DrawerContainerSizeTest>(parameters => parameters
@@ -867,30 +876,56 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("#drawer-container").GetStyle().Single(a => a.Name == "--mud-drawer-height-top").Value.Should().Be("250px");
         }
 
+        /// <summary>
+        /// Test for issue #6791: Verifies that a fixed drawer inside a <see cref="MudLayout"/>, where the layout is the only source of the width, updates that width when <see cref="MudDrawer.Width"/> changes.
+        /// </summary>
         [Test]
-        public async Task DrawerContainer_WidthChanged_DoesNotRenderRepeatedlyAsync()
+        public async Task DrawerLayout_FixedDrawerWidthChanged_UpdatesLayoutVariable()
         {
+            _ = AddBrowserViewportService();
+            var comp = Context.Render<DrawerLayoutSizeTest>(parameters => parameters
+                .Add(x => x.Width, "150px"));
+
+            // A fixed non-temporary drawer emits no width of its own, so the layout carries the only width.
+            comp.Find("aside.mud-drawer").GetStyle().ToList().Should().NotContain(a => a.Name == "--mud-drawer-width");
+            comp.Find("#drawer-layout").GetStyle().Single(a => a.Name == "--mud-drawer-width-left").Value.Should().Be("150px");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Width, "250px"));
+
+            comp.Find("#drawer-layout").GetStyle().Single(a => a.Name == "--mud-drawer-width-left").Value.Should().Be("250px");
+        }
+
+        /// <summary>
+        /// Test for issue #6791: Verifies that repeatedly changing <see cref="MudDrawer.Width"/> costs the container a bounded number of renders instead of looping.
+        /// </summary>
+        [Test]
+        public async Task DrawerContainer_WidthChanged_RendersContainerBoundedNumberOfTimes()
+        {
+            // A registered-parameter change on the drawer costs the container 5 renders, and a set that changes nothing costs 2.
+            // These bounds leave room for renderer batching to shift a little and only have to catch the drawer and the container re-rendering each other without settling.
+            const int MaxRendersPerChange = 8;
+            const int MaxRendersPerNoOp = 4;
+
             _ = AddBrowserViewportService();
             var comp = Context.Render<DrawerContainerSizeTest>(parameters => parameters
                 .Add(x => x.Width, "150px"));
             var container = comp.FindComponent<MudDrawerContainer>();
 
-            var changedRenders = new List<int>();
             foreach (var width in new[] { "250px", "350px", "450px" })
             {
                 var before = container.RenderCount;
                 await comp.SetParametersAndRenderAsync(parameters => parameters
                     .Add(x => x.Width, width));
-                changedRenders.Add(container.RenderCount - before);
+
+                (container.RenderCount - before).Should().BePositive().And.BeLessThanOrEqualTo(MaxRendersPerChange);
             }
 
-            var beforeUnchanged = container.RenderCount;
+            var beforeNoOp = container.RenderCount;
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Width, "450px"));
-            var unchangedRenders = container.RenderCount - beforeUnchanged;
 
-            changedRenders.Should().AllBeEquivalentTo(changedRenders[0]);
-            unchangedRenders.Should().BeLessThan(changedRenders[0]);
+            (container.RenderCount - beforeNoOp).Should().BeLessThanOrEqualTo(MaxRendersPerNoOp);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -45,8 +45,6 @@ namespace MudBlazor
             registerScope.RegisterParameter<bool>(nameof(RightToLeft))
                 .WithParameter(() => RightToLeft)
                 .WithChangeHandler(OnRightToLeftParameterChanged);
-            // The container renders before this component's new parameters are applied, so it reads the previous values off this instance.
-            // Re-render it once the new values have landed.
             registerScope.RegisterParameter<string?>(nameof(Width))
                 .WithParameter(() => Width)
                 .WithChangeHandler(DrawerContainerUpdate);

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -45,8 +45,8 @@ namespace MudBlazor
             registerScope.RegisterParameter<bool>(nameof(RightToLeft))
                 .WithParameter(() => RightToLeft)
                 .WithChangeHandler(OnRightToLeftParameterChanged);
-            // The container reads these off this instance while rendering itself, which happens before this
-            // component's new parameters are applied, so it needs to be re-rendered once they are.
+            // The container renders before this component's new parameters are applied, so it reads the previous values off this instance.
+            // Re-render it once the new values have landed.
             registerScope.RegisterParameter<string?>(nameof(Width))
                 .WithParameter(() => Width)
                 .WithChangeHandler(DrawerContainerUpdate);

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -45,6 +45,17 @@ namespace MudBlazor
             registerScope.RegisterParameter<bool>(nameof(RightToLeft))
                 .WithParameter(() => RightToLeft)
                 .WithChangeHandler(OnRightToLeftParameterChanged);
+            // The container reads these off this instance while rendering itself, which happens before this
+            // component's new parameters are applied, so it needs to be re-rendered once they are.
+            registerScope.RegisterParameter<string?>(nameof(Width))
+                .WithParameter(() => Width)
+                .WithChangeHandler(DrawerContainerUpdate);
+            registerScope.RegisterParameter<string?>(nameof(MiniWidth))
+                .WithParameter(() => MiniWidth)
+                .WithChangeHandler(DrawerContainerUpdate);
+            registerScope.RegisterParameter<string?>(nameof(Height))
+                .WithParameter(() => Height)
+                .WithChangeHandler(DrawerContainerUpdate);
         }
 
         // A mini drawer behaves like a temporary drawer below its breakpoint, but only for a finite breakpoint.
@@ -251,7 +262,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>null</c>.  Values such as <c>300px</c> and <c>30%</c> are supported.  Applies to non-fixed or <see cref="DrawerVariant.Temporary"/> drawers anchored to the left or right.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState(ParameterUsage = ParameterUsageOptions.None)]
         [Category(CategoryTypes.Drawer.Appearance)]
         public string? Width { get; set; }
 
@@ -261,7 +272,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>null</c>.  Values such as <c>300px</c> and <c>30%</c> are supported. Applies to <see cref="DrawerVariant.Mini"/> drawers achored to the left or right.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState(ParameterUsage = ParameterUsageOptions.None)]
         [Category(CategoryTypes.Drawer.Appearance)]
         public string? MiniWidth { get; set; }
 
@@ -271,7 +282,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>null</c>.  Values such as <c>300px</c> and <c>30%</c> are supported. Applies to drawers achored to the top or bottom.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState(ParameterUsage = ParameterUsageOptions.None)]
         [Category(CategoryTypes.Drawer.Appearance)]
         public string? Height { get; set; }
 


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/6791.

Changing a `MudDrawer`'s `Width` at runtime only reaches `MudDrawerContainer` one render late. The drawer panel resizes immediately, but the container's `--mud-drawer-width-left` custom property, and therefore the margin on the content beside it, keeps showing the previous value until some later render happens to refresh it. Cycling the width through 150, 250, 350 and 450px, the container reported 150px while the drawer already measured 250, then 250 against 350, and so on for every click.

The container builds its style by reading `Width`, `MiniWidth` and `Height` off the live child drawer instance. Being the parent, it renders before the child's new parameters have been applied, so it publishes stale values. `Open`, `ClipMode`, `Breakpoint` and `RightToLeft` already avoid this by registering as `ParameterState` with a change handler that calls `DrawerContainerUpdate`; the three size parameters had no registration at all. This adds them and reuses that handler. `Height` and `MiniWidth` had the identical gap and each has its own test. `MiniWidth` is arguably the headline case, since the issue reporter was using `DrawerVariant.Mini`.

Two things for a reviewer to weigh.

A registered-parameter change costs 5 container renders. That is not new, it is the existing price of the `DrawerContainerUpdate` mechanism, and an `Open` change already cost exactly 5 before this change; `Width` now simply costs what `Open` always cost. The three handlers coalesce into one render pass, and a test bounds the cost so it cannot quietly grow.

`Anchor` and `Variant` are left alone deliberately, and they are worse than the geometry parameters rather than better. The container also reads those, and they never recover, because nothing subsequently re-renders it. Flipping `Anchor` from Start to End moves the drawer to the right while `.mud-main-content` keeps its 150px left margin and no right margin, so content sits under the drawer; switching to `Mini` leaves the content margin at the full width and the `mud-drawer-open-mini-*` rules never activate. Those are structural rather than geometry and want their own change, but they are a real defect, not a theoretical one.

Also adjacent and pre-existing, flagged so it is not mistaken for fallout: clearing `Height` back to null at runtime leaves the drawer on a stale measured `_height`, because `UpdateHeightAsync` only runs on first render and on an `Open` change.
