### PR TITLE
MudDataGrid: Honor a custom Comparer in the live selection set

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSelectedItemsComparerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSelectedItemsComparerTest.razor
@@ -1,0 +1,61 @@
+﻿<MudDataGrid T="Person" Items="@Items" Comparer="@ItemComparer" MultiSelection="true" @bind-SelectedItems="SelectedItems">
+    <Columns>
+        <SelectColumn T="Person" />
+        <PropertyColumn Property="x => x.Id" />
+        <PropertyColumn Property="x => x.Name" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "Rows must render selected when SelectedItems holds different instances which are equal under the custom Comparer";
+
+    public IdComparer ItemComparer { get; } = new();
+
+    public List<Person> Items { get; } =
+    [
+        new Person(1, "Alpha"),
+        new Person(2, "Beta"),
+        new Person(3, "Gamma")
+    ];
+
+    public HashSet<Person> SelectedItems { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        // Distinct instances which only match rows 1 and 3 under ItemComparer, never under reference equality.
+        SelectedItems = new HashSet<Person>(ItemComparer) { new Person(1, "Alpha copy"), new Person(3, "Gamma copy") };
+    }
+
+    public void ReapplySelectedItems()
+    {
+        SelectedItems = new HashSet<Person>(ItemComparer) { new Person(2, "Beta copy") };
+        StateHasChanged();
+    }
+
+    public class Person
+    {
+        public Person(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
+    }
+
+    public class IdComparer : IEqualityComparer<Person>
+    {
+        public int EqualsCallCount { get; private set; }
+
+        public bool Equals(Person? x, Person? y)
+        {
+            EqualsCallCount++;
+
+            return x?.Id == y?.Id;
+        }
+
+        public int GetHashCode(Person obj) => obj.Id;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -586,6 +586,30 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridSelectedItemsHonorCustomComparer()
+        {
+            var comp = Context.Render<DataGridSelectedItemsComparerTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectedItemsComparerTest.Person>>();
+
+            var checkboxes = dataGrid.FindAll("tbody input[type=checkbox]");
+            checkboxes[0].IsChecked().Should().BeTrue();
+            checkboxes[1].IsChecked().Should().BeFalse();
+            checkboxes[2].IsChecked().Should().BeTrue();
+
+            dataGrid.Instance.Selection.Comparer.Should().BeSameAs(comp.Instance.ItemComparer);
+
+            // The rows are checked because the comparer was consulted, not because the instances happened to match.
+            comp.Instance.ItemComparer.EqualsCallCount.Should().BeGreaterThan(0);
+
+            await comp.InvokeAsync(comp.Instance.ReapplySelectedItems);
+
+            checkboxes = dataGrid.FindAll("tbody input[type=checkbox]");
+            checkboxes[0].IsChecked().Should().BeFalse();
+            checkboxes[1].IsChecked().Should().BeTrue();
+            checkboxes[2].IsChecked().Should().BeFalse();
+        }
+
+        [Test]
         public async Task DataGridSingleSelection()
         {
             var comp = Context.Render<DataGridSingleSelectionTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -104,6 +104,10 @@ namespace MudBlazor
             _expandSingleRowState = registerScope.RegisterParameter<bool>(nameof(ExpandSingleRow))
                 .WithParameter(() => ExpandSingleRow)
                 .WithChangeHandler(OnExpandSingleRowChangedAsync);
+
+            registerScope.RegisterParameter<IEqualityComparer<T>?>(nameof(Comparer))
+                .WithParameter(() => Comparer)
+                .WithChangeHandler(OnComparerChanged);
         }
 
         protected string Classname =>
@@ -1394,7 +1398,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>null</c>. When set, this comparer will be used to determine if a row is selected.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState(ParameterUsage = ParameterUsageOptions.None)]
         public IEqualityComparer<T>? Comparer { get; set; } = EqualityComparer<T>.Default;
 
         /// <summary>
@@ -1650,6 +1654,12 @@ namespace MudBlazor
                 Selection.Clear();
                 Selection.UnionWith(args.Value);
             }
+        }
+
+        private void OnComparerChanged(ParameterChangedEventArgs<IEqualityComparer<T>?> args)
+        {
+            // A HashSet keeps the comparer it was constructed with, so Selection has to be rebuilt to adopt the new one.
+            Selection = new HashSet<T>(Selection, args.Value);
         }
 
         private async Task OnExpandSingleRowChangedAsync(ParameterChangedEventArgs<bool> args)


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/13008 and https://github.com/MudBlazor/MudBlazor/issues/12820.

Setting `Comparer` on a `MudDataGrid` has no effect on which rows render as checked. Seeding `SelectedItems` with instances that are equal only under the custom comparer leaves every checkbox unchecked, and replacing `Items` with new but equal instances silently drops the existing selection.

The grid's constructor builds `Selection = new HashSet<T>(Comparer)`, but constructors run before Blazor applies parameters, so `Comparer` is still its field initializer, `EqualityComparer<T>.Default`. A `HashSet` keeps the comparer it was constructed with, and `Selection` was only ever mutated in place afterwards, so `CellContext.Selected`, which is what each row checkbox binds to, consulted the default comparer for the grid's entire life. This registers `Comparer` in the existing parameter scope and rebuilds `Selection` from its current contents when the value arrives. The other sets built from `Comparer` are constructed at call time and were already correct.

Two things a reviewer should weigh. First, this is a deliberate behaviour change: with a custom comparer, `Selection` now dedups by it, so anyone who previously held two comparer-equal rows in the selection will see them collapse to one. Second, the existing `DataGridCustomComparer` test still passes, but it encodes the workaround users had to write, setting `Comparer` to null and rebuilding `Selection` by hand. This makes that unnecessary without breaking it.

Separately and out of scope: `SelectedItems` is still only written back through `@bind-SelectedItems`, so an unbound grid leaves the property empty even while rows are visibly selected. That is comparer-independent and looks like its own issue.
