### PR TITLE
MudDataGrid: Keep the container scrollable when sticky columns are used

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CarouselTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CarouselTests.cs
@@ -345,5 +345,37 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button.mud-inherit-text").Count.Should().Be(2);
             comp.FindAll("button.mud-primary-text").Count.Should().Be(0);
         }
+
+        [Test]
+        public void Carousel_SelectsFirstItemAddedAfterFirstRender()
+        {
+            var source = new List<string>();
+            var selectedIndexes = new List<int>();
+            var comp = Context.Render<MudCarousel<string>>(parameters => parameters
+                .Add(p => p.ItemsSource, source)
+                .Add(p => p.AutoCycle, false)
+                .Add(p => p.SelectedIndexChanged, index => selectedIndexes.Add(index)));
+
+            comp.Instance.SelectedIndex.Should().Be(-1);
+            comp.FindAll("div.mud-carousel-item").Count.Should().Be(0);
+
+            // The first item to arrive after an empty first render must become the selected one.
+            source.Add("Item 1");
+            comp.Render();
+
+            comp.Instance.Items.Count.Should().Be(1);
+            comp.Instance.SelectedIndex.Should().Be(0);
+            comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[0]);
+            comp.FindAll("div.mud-carousel-item").Count.Should().Be(1);
+            selectedIndexes.Should().Equal(0);
+
+            // Later items must not steal the selection.
+            source.Add("Item 2");
+            comp.Render();
+
+            comp.Instance.Items.Count.Should().Be(2);
+            comp.Instance.SelectedIndex.Should().Be(0);
+            selectedIndexes.Should().Equal(0);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4821,11 +4821,28 @@ namespace MudBlazor.UnitTests.Components
             footer.GetAttribute("style").Should().Contain("left:0px");
 
             var body = dataGrid.Find(".mud-table-container");
-            body.GetAttribute("style").Should().Contain("width:max-content");
-            body.GetAttribute("style").Should().Contain("overflow:clip");
+            body.GetAttribute("style").Should().NotContain("width:max-content");
+            body.GetAttribute("style").Should().NotContain("overflow:clip");
+
+            var dropContainer = dataGrid.Find(".mud-table-container .mud-drop-container");
+            dropContainer.GetAttribute("style").Should().Contain("width:max-content");
 
             dataGrid.Find("th").ClassList.Should().Contain("sticky-left");
             dataGrid.FindAll("th").Last().ClassList.Should().Contain("sticky-right");
+        }
+
+        [Test]
+        public async Task DataGridStickyColumnsKeepContainerScrollable()
+        {
+            var comp = Context.Render<DataGridStickyColumnsResizerTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridStickyColumnsResizerTest.Model>>();
+
+            dataGrid.Find(".mud-table-container").GetAttribute("style").Should().NotContain("overflow", because: "the container has to stay a scroll container so a Height can still scroll vertically");
+
+            await comp.FindComponent<MudSwitch<bool>>().Find("input").ChangeAsync(new ChangeEventArgs { Value = false });
+
+            dataGrid.Find(".mud-table-container").GetAttribute("style").Should().Contain("width:max-content");
+            dataGrid.FindAll(".mud-table-container .mud-drop-container[style*='width:max-content']").Should().BeEmpty();
         }
 
         [Test]

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -256,6 +256,9 @@ namespace MudBlazor
             if (Items.Count - 1 == SelectedIndex)
                 _currentColor = item.Color;
 
+            if (SelectedIndex < 0)
+                MoveTo(0);
+
             StateHasChanged();
         }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -38,7 +38,7 @@
                 }
             }
             <div @ref=_gridElement class="@TableClass" style="@TableStyle">
-                <MudDropContainer @ref="_dropContainer" T="Column<T>" Items="@RenderedColumns" ItemsSelector="(item, dropzone) => RenderedColumnsItemsSelector(item, dropzone)" ItemDropped="ItemUpdatedAsync" CanDropClass="@DropAllowedClass" NoDropClass="@DropNotAllowedClass" ApplyDropClassesOnDragStarted="@ApplyDropClassesOnDragStarted">
+                <MudDropContainer @ref="_dropContainer" T="Column<T>" Style="@DropContainerStyle" Items="@RenderedColumns" ItemsSelector="(item, dropzone) => RenderedColumnsItemsSelector(item, dropzone)" ItemDropped="ItemUpdatedAsync" CanDropClass="@DropAllowedClass" NoDropClass="@DropNotAllowedClass" ApplyDropClassesOnDragStarted="@ApplyDropClassesOnDragStarted">
                     <ChildContent>
                         <table @attributes="TableAttributes" class="mud-table-root">
                             @if (ColGroup != null)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -136,9 +136,15 @@ namespace MudBlazor
         protected string TableStyle =>
             new StyleBuilder()
                 .AddStyle("height", Height, !string.IsNullOrWhiteSpace(Height))
-                .AddStyle("width", "max-content", when: HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container)
-                .AddStyle("overflow", "clip", when: (HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container) && HasStickyColumns)
+                .AddStyle("width", "max-content", when: (HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container) && !HasStickyColumns)
                 .AddStyle("display", "block", when: HorizontalScrollbar)
+                .Build();
+
+        // Sticky cells anchor to the nearest scroll container, so the container has to stay the element that
+        // scrolls in both directions. Widening the table beyond it is done one level down instead.
+        protected string DropContainerStyle =>
+            new StyleBuilder()
+                .AddStyle("width", "max-content", when: (HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container) && HasStickyColumns)
                 .Build();
 
         protected string TableClass =>

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -638,6 +638,16 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
       padding-inline-start: unset;
     }
 
+    // Group header cells carry no data-label.
+    // Without this their empty :before still counts as a flex item, so space-between pushes the group content to the far edge.
+    .mud-table-cell.mud-datagrid-group {
+      justify-content: flex-start;
+
+      &:before {
+        content: none;
+      }
+    }
+
     &.mud-table-small-alignright .mud-table-cell:before {
       margin-right: auto;
     }


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/9083 and https://github.com/MudBlazor/MudBlazor/issues/7709.

A grid with `ColumnResizeMode.Container` (or `HorizontalScrollbar`) plus any sticky column cannot be scrolled at all. `TableStyle` puts `overflow: clip` on `.mud-table-container`, and because that is a shorthand it kills the vertical axis along with the horizontal one. Measured on the repro: computed `overflowX` and `overflowY` both `clip`, `scrollHeight` 1690 against `clientHeight` 260, and assigning `scrollTop = 200` reads back 0. Two control grids that change only one of the two conditions scroll normally.

The `clip` was deliberate. It is the one overflow value that does not create a scroll container, which pushed sticky anchoring up to the grid root. The tempting narrowing to `overflow-x: clip` does not work: alongside the container's inherited `overflow-y: auto` the cascade computes it to `hidden`, which does create a scroll container, and sticky silently dies. I measured that specifically rather than assuming it.

Instead the container stays the element that scrolls on both axes and `width: max-content` moves down onto the inner drop container. That is the same arrangement `ResizeMode.Column` with sticky columns already uses, and that path was never broken. Verified with a real resizer drag as well as scripted scrolling, and the sticky cell is confirmed genuinely pinned rather than merely at rest: the container's `scrollLeft` is 150 while the first column sits at offset 0.

The thing to weigh: with sticky columns the horizontal scrollbar moves from the grid root to the container, so it now sits between the toolbar and the pager rather than below the whole grid. That matches `ResizeMode.Column`, but it does leave sticky and non-sticky container-resize grids inconsistent with each other. Sticky cells also now pin to the container's edge rather than the root's, which is arguably more correct but is a pixel change. Two now-inert leftovers, the sticky `left: 0` on the toolbar and pager and the root's `overflow-x: auto`, are left alone to keep the diff small.

Two assertions in `DataGridStickyColumnsResizer` changed. They asserted the container's style contained `width:max-content` and `overflow:clip`, which is a transcript of the broken implementation, and `overflow:clip` is the bug itself. The replacements are stronger rather than weaker: `width:max-content` is asserted on its new owner, the sticky class assertions are untouched, and a new test pins the invariant nobody was checking, that the container stays scrollable.
