### PR TITLE
Build: Pin .NET SDK to a feature band and manage upgrades via Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,9 +7,6 @@
         ":ignoreModulesAndTests",
         "mergeConfidence:all-badges"
     ],
-    "ignoreDeps": [
-        "dotnet-sdk"
-    ],
     "labels": [
         "dependency",
         "build"
@@ -25,6 +22,49 @@
         ]
     },
     "packageRules": [
+        {
+            "description": ".NET SDK versions are x.y.znn where z is the feature band and nn the in-band patch. Renovate's default versioning classifies BOTH 10.0.400->10.0.401 and 10.0.400->10.0.500 as 'patch'. Remap the band digit into the 'minor' slot so the two are separable.",
+            "matchDatasources": [
+                "dotnet-version"
+            ],
+            "matchPackageNames": [
+                "dotnet-sdk"
+            ],
+            "versioning": "regex:^(?<major>\\d+)\\.\\d+\\.(?<minor>\\d)(?<patch>\\d{2})$",
+            "separateMinorPatch": true
+        },
+        {
+            "description": "In-band SDK servicing patches are a no-op for CI (setup-dotnet installs the channel head of the band regardless of the patch digits) and raising the pinned floor would only break contributors who have not patched this month. No PRs for them.",
+            "matchDatasources": [
+                "dotnet-version"
+            ],
+            "matchPackageNames": [
+                "dotnet-sdk"
+            ],
+            "matchUpdateTypes": [
+                "patch"
+            ],
+            "enabled": false
+        },
+        {
+            "description": "A new SDK feature band swaps Roslyn, the Razor source generator, and dotnet format. Surface it as one reviewable PR instead of letting CI roll onto it unannounced. This grouping also overrides the 'dotnet monorepo' group from group:monorepos, which would otherwise absorb the SDK bump.",
+            "matchDatasources": [
+                "dotnet-version"
+            ],
+            "matchPackageNames": [
+                "dotnet-sdk"
+            ],
+            "matchUpdateTypes": [
+                "major",
+                "minor"
+            ],
+            "groupName": "dotnet sdk feature band",
+            "groupSlug": "dotnet-sdk-feature-band",
+            "reviewers": [
+                "team:core-team"
+            ],
+            "minimumReleaseAge": "5 days"
+        },
         {
             "matchPackageNames": [
                 "Microsoft.CodeAnalysis**"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,41 +23,14 @@
     },
     "packageRules": [
         {
-            "description": ".NET SDK versions are x.y.znn where z is the feature band and nn the in-band patch. Renovate's default versioning classifies BOTH 10.0.400->10.0.401 and 10.0.400->10.0.500 as 'patch'. Remap the band digit into the 'minor' slot so the two are separable.",
+            "description": ".NET SDK feature bands (the z in x.y.znn) swap Roslyn, the Razor source generator, and dotnet format; the last two bands (10.0.300, 10.0.400) each broke CI on release day. Allowing only band-floor versions (patch 00) means in-band servicing patches get no PR (CI installs the band head regardless, and raising the pinned floor would only break contributors who have not patched), while a new band arrives as one reviewable PR after a soak. The group also overrides the 'dotnet monorepo' group from group:monorepos, which would otherwise absorb the bump. Renovate classifies a band jump as 'patch', so any future patch-wide automerge rule must exclude dotnet-sdk.",
             "matchDatasources": [
                 "dotnet-version"
             ],
             "matchPackageNames": [
                 "dotnet-sdk"
             ],
-            "versioning": "regex:^(?<major>\\d+)\\.\\d+\\.(?<minor>\\d)(?<patch>\\d{2})$",
-            "separateMinorPatch": true
-        },
-        {
-            "description": "In-band SDK servicing patches are a no-op for CI (setup-dotnet installs the channel head of the band regardless of the patch digits) and raising the pinned floor would only break contributors who have not patched this month. No PRs for them.",
-            "matchDatasources": [
-                "dotnet-version"
-            ],
-            "matchPackageNames": [
-                "dotnet-sdk"
-            ],
-            "matchUpdateTypes": [
-                "patch"
-            ],
-            "enabled": false
-        },
-        {
-            "description": "A new SDK feature band swaps Roslyn, the Razor source generator, and dotnet format. Surface it as one reviewable PR instead of letting CI roll onto it unannounced. This grouping also overrides the 'dotnet monorepo' group from group:monorepos, which would otherwise absorb the SDK bump.",
-            "matchDatasources": [
-                "dotnet-version"
-            ],
-            "matchPackageNames": [
-                "dotnet-sdk"
-            ],
-            "matchUpdateTypes": [
-                "major",
-                "minor"
-            ],
+            "allowedVersions": "/^\\d+\\.\\d+\\.\\d00$/",
             "groupName": "dotnet sdk feature band",
             "groupSlug": "dotnet-sdk-feature-band",
             "reviewers": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Please make sure that you follow our [code of conduct](/CODE_OF_CONDUCT.md)
 
 ## Minimal Prerequisites to Compile from Source
 
--   [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (pinned in `global.json`; it can build the older targets too)
+-   [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0), 10.0.4xx feature band (pinned in `global.json`; any 10.0.4xx patch works — it can build the older targets too)
 
 The `MudBlazor` library multi-targets net8.0, net9.0, and net10.0. `dotnet test` and IDE builds only compile the framework that is needed (the tests build just net10.0), but a direct `dotnet build src/MudBlazor` compiles all three. For a faster single-framework build while developing, pass `-f`:
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestFeature"
+    "version": "10.0.400",
+    "rollForward": "latestPatch",
+    "errorMessage": "MudBlazor builds on the .NET SDK 10.0.4xx feature band (pinned in global.json). Install it from https://dotnet.microsoft.com/download/dotnet/10.0 - any 10.0.4xx patch works. Run 'dotnet --list-sdks' to see what you have."
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
## Why

On 2026-08-11 (Patch Tuesday), the .NET SDK 10.0.400 feature band was published between 16:48 and 22:18 UTC, and CI adopted it the same evening: `global.json` has `"rollForward": "latestFeature"`, which `actions/setup-dotnet` turns into "install the newest 10.0 band" the moment one ships. The new Roslyn emitted CS8602 on pre-existing code in `MudBlazor.UnitTests.Viewer`, `TreatWarningsAsErrors` promoted it to an error, and every open PR went red (https://github.com/MudBlazor/MudBlazor/pull/13610, https://github.com/MudBlazor/MudBlazor/pull/13612, https://github.com/MudBlazor/MudBlazor/pull/13613) for 16.5 hours until https://github.com/MudBlazor/MudBlazor/pull/13614 landed a one-line fix.

This is the second consecutive band crossing to break CI: 10.0.300 broke the analyzer tests in May (https://github.com/MudBlazor/MudBlazor/issues/13204, which already recommended this pin).

New policy: **feature-band upgrades arrive as a reviewed Renovate PR** (roughly quarterly, 5-day soak). **In-band servicing patches stay automatic and PR-free** - those are the safe ones.

## Changes

### global.json

Pin `10.0.400` + `rollForward: latestPatch`. Zero behavior delta today: CI already resolves 10.0.400 on every job and is green on it. `latestPatch` accepts any installed 10.0.4xx and nothing else, so CI can never silently cross a band again.

The new `errorMessage` field (a .NET 10 global.json feature) replaces the default resolver error with an actionable one. Live-tested on a machine that only has 10.0.302 installed:

```
It was not possible to find any compatible framework version
  * You intended to execute a .NET SDK command:
      MudBlazor builds on the .NET SDK 10.0.4xx feature band (pinned in global.json). Install it from https://dotnet.microsoft.com/download/dotnet/10.0 - any 10.0.4xx patch works. Run 'dotnet --list-sdks' to see what you have.
```

Note on CI mechanics (verified against setup-dotnet v6 source): setup-dotnet translates `latestPatch` + `10.0.400` into `install-dotnet --channel 10.0.4xx`, i.e. CI always installs the current head of the band. Servicing patches therefore keep flowing to CI automatically with no Renovate involvement, and the pinned floor stays at `.400` so contributors who have not patched this month are never broken.

### .github/renovate.json

Remove `"ignoreDeps": ["dotnet-sdk"]` and add three rules:

1. **Versioning remap.** Renovate's default versioning for the SDK classifies BOTH `10.0.400 -> 10.0.401` (servicing patch) and `10.0.400 -> 10.0.500` (new compiler) as "patch". A regex versioning maps the band digit into the "minor" slot so the two are separable.
2. **No PRs for in-band patches** - they are a no-op for CI (see above) and would only raise the contributor floor.
3. **Band jumps become one grouped, reviewable PR** ("dotnet sdk feature band") with core-team review and `minimumReleaseAge: 5 days`. This grouping also overrides the `dotnet monorepo` group that `config:recommended` pulls in via `group:monorepos` - without it the SDK bump would be folded into routine NuGet churn. (The Renovate PR that was red during the incident was literally titled "Build: Update dotnet monorepo".)

### CONTRIBUTING.md

Prerequisites now name the 10.0.4xx feature band explicitly.

## Trade-off considered

`latestFeature`'s original value was convenience: switching to an old branch on a machine that only has newer SDKs still built. The cost of the pin is that checking out an old commit later requires installing that era's band - a one-time, side-by-side install, and the errorMessage embedded in that commit says exactly which one. The middle ground `rollForward: "feature"` (prefer 4xx, silently roll up when absent) was rejected: silent drift onto a newer compiler reproduces exactly the class of surprise this PR removes, just relocated to contributor machines (warnings and `dotnet format` behavior that disagree with CI).

## Maintenance note

When a future band PR from Renovate is merged (~3-4x/year), update the band references in `global.json`'s `errorMessage` and in CONTRIBUTING.md in that same PR. The literal `10.0.400` appears exactly once in global.json (the errorMessage deliberately says `10.0.4xx`) so Renovate's rewrite can never retarget the message text.

## Verification

- `npx --yes --package renovate -- renovate-config-validator` passes: "Config validated successfully against 1 file(s)" (same command the renovate-validation workflow runs).
- `global.json` and `.github/renovate.json` are valid JSON; `10.0.400` appears exactly once.
- `errorMessage` verified live against a 10.0.302-only host.
- CI is a zero-delta change: every job already installs 10.0.400 today.

## Contributor impact

You need any 10.0.4xx SDK; `winget install Microsoft.DotNet.SDK.10` currently installs the band head. Everything else (multi-targeting net8/net9/net10) is unchanged.
