### PR TITLE
MudDataGrid: Fix select-all showing checked when a disabled selected row offsets an unselected one

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -7005,6 +7005,62 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task SelectAll_WithSelectedDisabledRow_HeaderCheckboxNotFalselyChecked()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Enabled Selected", ShouldBeDisabled = false },
+                new() { Id = 2, Name = "Disabled Selected", ShouldBeDisabled = true },
+                new() { Id = 3, Name = "Enabled Unselected", ShouldBeDisabled = false },
+                new() { Id = 4, Name = "Disabled Unselected", ShouldBeDisabled = true }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Columns, SelectColumnWithFunc)
+            );
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.SelectedItems, new HashSet<TestDataItem> { items[0], items[1] }));
+
+            // The selected count matches the selectable count, but the selected disabled row must not stand in for the unselected enabled row.
+            var headerCheckbox = comp.FindComponent<MudCheckBox<bool?>>();
+            headerCheckbox.Instance.ReadValue.Should().BeNull();
+        }
+
+        [Test]
+        public async Task SelectAll_Toggle_PreservesSelectedDisabledRow()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Enabled Selected", ShouldBeDisabled = false },
+                new() { Id = 2, Name = "Disabled Selected", ShouldBeDisabled = true },
+                new() { Id = 3, Name = "Enabled Unselected", ShouldBeDisabled = false }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Columns, SelectColumnWithFunc)
+            );
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.SelectedItems, new HashSet<TestDataItem> { items[0], items[1] }));
+
+            var headerCheckbox = comp.FindComponent<MudCheckBox<bool?>>();
+
+            await comp.Find("th.mud-table-cell .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = true });
+            headerCheckbox.Instance.ReadValue.Should().BeTrue();
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(items);
+
+            // Deselecting all only removes the rows the header checkbox controls; the disabled row's selection survives.
+            await comp.Find("th.mud-table-cell .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = false });
+            headerCheckbox.Instance.ReadValue.Should().BeFalse();
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(new[] { items[1] });
+        }
+
+        [Test]
         public async Task SelectAll_GroupFooterCheckbox_AppliesToItsOwnGroupOnly()
         {
             var items = new List<TestDataItem>

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -7004,6 +7004,9 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
         }
 
+        /// <summary>
+        /// A selected disabled row must not stand in for an unselected enabled row in the select-all state: regression from https://github.com/MudBlazor/MudBlazor/pull/13596.
+        /// </summary>
         [Test]
         public async Task SelectAll_WithSelectedDisabledRow_HeaderCheckboxNotFalselyChecked()
         {
@@ -7029,6 +7032,9 @@ namespace MudBlazor.UnitTests.Components
             headerCheckbox.Instance.ReadValue.Should().BeNull();
         }
 
+        /// <summary>
+        /// Toggling select-all only affects the rows its checkbox controls, so a disabled row selected from code survives: https://github.com/MudBlazor/MudBlazor/pull/13596.
+        /// </summary>
         [Test]
         public async Task SelectAll_Toggle_PreservesSelectedDisabledRow()
         {

--- a/src/MudBlazor/Components/DataGrid/FooterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterContext.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace MudBlazor
@@ -50,28 +49,7 @@ namespace MudBlazor
         /// <summary>
         /// Indicates whether all values are currently selected.
         /// </summary>
-        public bool? IsAllSelected
-        {
-            get
-            {
-                if (GroupItemsFunc() is { } groupItems)
-                {
-                    return _dataGrid.GetGroupSelectionState(groupItems);
-                }
-
-                if (_dataGrid.Selection is not null && (Items?.Any() ?? false))
-                {
-                    if (_dataGrid.Selection.Count == 0)
-                    {
-                        return false;
-                    }
-
-                    return _dataGrid.Selection.Count == _dataGrid.GetSelectableItems().Count() ? true : null;
-                }
-
-                return false;
-            }
-        }
+        public bool? IsAllSelected => _dataGrid.GetSelectionState(GroupItemsFunc() ?? Items);
 
         /// <summary>
         /// Creates a new instance.

--- a/src/MudBlazor/Components/DataGrid/HeaderContext.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderContext.cs
@@ -41,23 +41,7 @@ namespace MudBlazor
         /// <summary>
         /// Indicates whether all items are currently selected.
         /// </summary>
-        public bool? IsAllSelected
-        {
-            get
-            {
-                if (_dataGrid.Selection is not null && (Items?.Any() ?? false))
-                {
-                    if (_dataGrid.Selection.Count == 0)
-                    {
-                        return false;
-                    }
-
-                    return _dataGrid.Selection.Count == _dataGrid.GetSelectableItems().Count() ? true : null;
-                }
-
-                return false;
-            }
-        }
+        public bool? IsAllSelected => _dataGrid.GetSelectionState(Items);
 
         /// <summary>
         /// Creates a new instance.

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2166,11 +2166,16 @@ namespace MudBlazor
             if (!MultiSelection)
                 return;
 
-            Selection.Clear(); // Clear selection first, regardless of selecting or unselecting all.
+            var selectableItems = GetSelectableItems();
 
-            if (value) // Logic for selecting all
+            if (value)
             {
-                Selection.UnionWith(GetSelectableItems());
+                Selection.UnionWith(selectableItems);
+            }
+            else
+            {
+                // Only remove the rows the checkbox controls so selections it cannot restore, such as disabled rows, survive.
+                Selection.ExceptWith(selectableItems);
             }
 
             // Create new HashSet instance to ensure ParameterState's comparer detects changes
@@ -2231,12 +2236,12 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// The state of a group's select-all checkbox: <c>true</c> when every selectable row of the group is selected, <c>false</c> when none of them is, otherwise <c>null</c>.
+        /// The state of a select-all checkbox covering <paramref name="items"/>: <c>true</c> when every selectable row is selected, <c>false</c> when none of them is, otherwise <c>null</c>.
         /// </summary>
-        /// <param name="groupItems">The rows belonging to the group.</param>
-        internal bool? GetGroupSelectionState(IEnumerable<T> groupItems)
+        /// <param name="items">The rows the checkbox covers, e.g. all displayed rows for the header checkbox or a group's rows for a group footer checkbox.</param>
+        internal bool? GetSelectionState(IEnumerable<T> items)
         {
-            var selectableItems = GetSelectableItems(groupItems).ToList();
+            var selectableItems = GetSelectableItems(items).ToList();
             var selectedCount = selectableItems.Count(Selection.Contains);
 
             if (selectedCount == 0)


### PR DESCRIPTION
## Regression

Found by the 2026-08-20 browser sweep of v9.9.0 candidate `56f4cc01`; introduced by [#13596](https://github.com/MudBlazor/MudBlazor/pull/13596) (the #13224 stuck-indeterminate fix).

`HeaderContext.IsAllSelected` / `FooterContext.IsAllSelected` returned checked when `Selection.Count == GetSelectableItems().Count()` — a count-equality between two different sets. A selected row that is *not* selectable (disabled via `SelectColumn.DisabledFunc`, or hidden by a filter) inflates `Selection.Count`, so with rows Ada (enabled, selected), Grace (disabled, selected), Linus (enabled, unselected), Margaret (disabled, unselected), the header read 2 == 2 and showed fully checked while Linus was unselected. Clicking the falsely checked header then ran `SetSelectAllAsync(false)` → `Selection.Clear()`, silently wiping every selection including Grace, whose own checkbox is disabled so the user cannot restore it.

## Change

- `IsAllSelected` now uses membership, not counts: the whole-grid state is computed by the same `GetSelectionState` used by group footer checkboxes since #13410 (`GetGroupSelectionState` renamed, since it is no longer group-specific). True only when every displayed selectable row is actually in the selection; false when none of them is — including when the only selected rows are ones the checkbox cannot control, matching the group checkbox's existing semantics.
- Both contexts' duplicated `IsAllSelected` bodies collapse to one-line calls into the grid.
- `SetSelectAllAsync(false)` now mirrors `SetGroupSelectAllAsync`: `ExceptWith(selectable)` instead of `Selection.Clear()`. Deselect-all only removes the rows the checkbox controls, so a disabled row's programmatic selection survives the toggle. (Select-all correspondingly no longer clears first; it unions, same as groups.)

Decision note: the `Clear()` → `ExceptWith` change means header deselect-all no longer purges selections of rows currently hidden by a filter. That is the same rule the group select-all has always had, and it is what makes the disabled-row selection survivable, but it is a behavior change on top of the icon fix — flagging it in case you want it split out.

## Verification

- New tests: `SelectAll_WithSelectedDisabledRow_HeaderCheckboxNotFalselyChecked` (the sweep's exact 4-row scenario → header must read indeterminate) and `SelectAll_Toggle_PreservesSelectedDisabledRow` (select-all adds only enabled rows; deselect-all keeps the disabled selected row).
- Full `DataGridTests` class: 271/271 pass, including all of #13596's and #13410's select-all tests unchanged.
- Browser (Blazor Server harness, real circuit, the sweep scenario exactly): initial state header+footer both render `IndeterminateCheckBox` (previously `CheckBox`); clicking select-all → "Ada, Grace, Linus" and header checked (Margaret stays unselected); clicking again → "Grace" survives, header unchecked, Grace's row checkbox still checked.
